### PR TITLE
Add error for 2FA Token Required

### DIFF
--- a/aiounifi/errors.py
+++ b/aiounifi/errors.py
@@ -27,10 +27,15 @@ class NoPermission(AiounifiException):
     """Users permissions are read only."""
 
 
+class TwoFaTokenRequired(AiounifiException):
+    """2 factor authentication token required."""
+
+
 ERRORS = {
-    'api.err.LoginRequired': LoginRequired,
-    'api.err.Invalid': Unauthorized,
-    'api.err.NoPermission': NoPermission
+    "api.err.LoginRequired": LoginRequired,
+    "api.err.Invalid": Unauthorized,
+    "api.err.NoPermission": NoPermission,
+    "api.err.Ubic2faTokenRequired": TwoFaTokenRequired,
 }
 
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -14,6 +14,7 @@ from aiounifi import (
     NoPermission,
     RequestError,
     ResponseError,
+    TwoFaTokenRequired,
     Unauthorized,
 )
 from aiounifi.api import SOURCE_DATA, SOURCE_EVENT
@@ -764,6 +765,18 @@ async def test_controller_request_raise_error_raise_no_permission(
         payload={"errors": ["api.err.NoPermission"]},
     )
     with pytest.raises(NoPermission):
+        await unifi_controller.login()
+
+
+async def test_controller_request_raise_2fa_token_required(
+    mock_aioresponse, unifi_controller
+):
+    """Verify request raise 2fa token required on a websocket error."""
+    mock_aioresponse.post(
+        "https://host:8443/api/login",
+        payload={"errors": ["api.err.Ubic2faTokenRequired"]},
+    )
+    with pytest.raises(TwoFaTokenRequired):
         await unifi_controller.login()
 
 


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/35459

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/unifi/controller.py", line 426, in get_controller
    await controller.login()
  File "/usr/local/lib/python3.7/site-packages/aiounifi/controller.py", line 86, in login
    await self.request("post", url=url, json=auth)
  File "/usr/local/lib/python3.7/site-packages/aiounifi/controller.py", line 220, in request
    _raise_on_error(response)
  File "/usr/local/lib/python3.7/site-packages/aiounifi/controller.py", line 238, in _raise_on_error
    raise_error(data["meta"]["msg"])
  File "/usr/local/lib/python3.7/site-packages/aiounifi/errors.py", line 40, in raise_error
    raise cls("{}".format(type))
aiounifi.errors.AiounifiException: api.err.Ubic2faTokenRequired