### PR TITLE
Support client reconnect command

### DIFF
--- a/aiounifi/clients.py
+++ b/aiounifi/clients.py
@@ -26,6 +26,11 @@ class Clients(APIItems):
         data = {"mac": mac, "cmd": "unblock-sta"}
         await self._request("post", URL_CLIENT_STATE_MANAGER, json=data)
 
+    async def async_reconnect(self, mac: str) -> None:
+        """Force a client to reconnect to the network."""
+        data = {"mac": mac, "cmd": "kick-sta"}
+        await self._request("post", URL_CLIENT_STATE_MANAGER, json=data)
+
 
 class ClientsAll(APIItems):
     """Represents all client network devices."""

--- a/aiounifi/clients.py
+++ b/aiounifi/clients.py
@@ -27,7 +27,7 @@ class Clients(APIItems):
         await self._request("post", URL_CLIENT_STATE_MANAGER, json=data)
 
     async def async_reconnect(self, mac: str) -> None:
-        """Force a client to reconnect to the network."""
+        """Force a wireless client to reconnect to the network."""
         data = {"mac": mac, "cmd": "kick-sta"}
         await self._request("post", URL_CLIENT_STATE_MANAGER, json=data)
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -74,3 +74,11 @@ async def test_clients(mock_aioresponse, unifi_controller):
         "https://host:8443/api/s/default/cmd/stamgr",
         json={"mac": WIRELESS_CLIENT["mac"], "cmd": "unblock-sta"},
     )
+
+    await clients.async_reconnect(WIRELESS_CLIENT["mac"])
+    assert verify_call(
+        mock_aioresponse,
+        "post",
+        "https://host:8443/api/s/default/cmd/stamgr",
+        json={"mac": WIRELESS_CLIENT["mac"], "cmd": "kick-sta"},
+    )


### PR DESCRIPTION
Support forcing a client to reconnect to the network.
The command is only valid for wireless clients.