### PR TITLE
Fix NPE when x-csrf-token is not present in API response

### DIFF
--- a/aiounifi/controller.py
+++ b/aiounifi/controller.py
@@ -92,7 +92,9 @@ class Controller:
         response = await self._request("get", url=self.url, allow_redirects=False)
         if response.status == 200:
             self.is_unifi_os = True
-            self.headers = {"x-csrf-token": response.headers.get("x-csrf-token")}
+            # the header isn't always set, prevent it being set to none, as it would cause a NPE when serializing the headers elsewhere 
+            if response.headers.get("x-csrf-token") is not None:
+                self.headers = {"x-csrf-token": response.headers.get("x-csrf-token")}
 
     async def login(self) -> None:
         """Log in to controller."""


### PR DESCRIPTION
I ran into an issue where the Unifi controller API doesn't seem to return a CSRF header (not sure why, but apparently we need to deal with it).

If that's the case, we will still set the header with a None value in `controller.py`. This in turn leads to an error being thrown in `aiohttp._http_writer._serialize_headers` later on, because it essentially causes an NPE trying to serialize an empty header value (which of course, makes no sense).

This change ensures the header is not set if it's not in the response, thereby solving the NPE. 

Stack trace before the fix was applied:
```
  File "/usr/local/lib/python3.9/site-packages/aiounifi/controller.py", line 108, in login
    await self._request("post", url=url, json=auth)
  File "/usr/local/lib/python3.9/site-packages/aiounifi/controller.py", line 274, in _request
    async with self.session.request(
  File "/usr/local/lib/python3.9/site-packages/aiohttp/client.py", line 1117, in __aenter__
    self._resp = await self._coro
  File "/usr/local/lib/python3.9/site-packages/aiohttp/client.py", line 542, in _request
    resp = await req.send(conn)
  File "/usr/local/lib/python3.9/site-packages/aiohttp/client_reqrep.py", line 668, in send
    await writer.write_headers(status_line, self.headers)
  File "/usr/local/lib/python3.9/site-packages/aiohttp/http_writer.py", line 118, in write_headers
    buf = _serialize_headers(status_line, headers)
  File "aiohttp/_http_writer.pyx", line 137, in aiohttp._http_writer._serialize_headers
  File "aiohttp/_http_writer.pyx", line 109, in aiohttp._http_writer.to_str
TypeError: Cannot serialize non-str key None
```