### PR TITLE
Add functionality to remove clients from controller

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
-    "python.formatting.provider": "black",
-    "python.testing.pytestEnabled": true
+  "python.formatting.provider": "black",
+  "python.testing.pytestEnabled": true,
+  "python.linting.pylintEnabled": true
 }

--- a/aiounifi/clients.py
+++ b/aiounifi/clients.py
@@ -69,6 +69,11 @@ class Client(APIItem):
         return self.raw.get("blocked", False)
 
     @property
+    def device_name(self) -> str:
+        """Device name of client."""
+        return self.raw.get("device_name", "")
+
+    @property
     def essid(self) -> str:
         """ESSID client is connected to."""
         return self.raw.get("essid", "")
@@ -154,9 +159,19 @@ class Client(APIItem):
         return self.raw.get("rx_bytes", 0)
 
     @property
+    def rx_bytes_r(self) -> int:
+        """Bytes recently received over wireless connection."""
+        return self.raw.get("rx_bytes-r", 0)
+
+    @property
     def tx_bytes(self) -> int:
         """Bytes transferred over wireless connection."""
         return self.raw.get("tx_bytes", 0)
+
+    @property
+    def tx_bytes_r(self) -> int:
+        """Bytes recently transferred over wireless connection."""
+        return self.raw.get("tx_bytes-r", 0)
 
     @property
     def uptime(self) -> int:
@@ -169,9 +184,19 @@ class Client(APIItem):
         return self.raw.get("wired-rx_bytes", 0)
 
     @property
+    def wired_rx_bytes_r(self) -> int:
+        """Bytes recently received over wired connection."""
+        return self.raw.get("wired-rx_bytes-r", 0)
+
+    @property
     def wired_tx_bytes(self) -> int:
         """Bytes transferred over wired connection."""
         return self.raw.get("wired-tx_bytes", 0)
+
+    @property
+    def wired_tx_bytes_r(self) -> int:
+        """Bytes recently transferred over wired connection."""
+        return self.raw.get("wired-tx_bytes-r", 0)
 
     def __repr__(self) -> str:
         """Return the representation."""

--- a/aiounifi/clients.py
+++ b/aiounifi/clients.py
@@ -1,6 +1,6 @@
 """Clients are devices on a UniFi network."""
 
-from typing import Optional
+from typing import List, Optional
 
 from .api import APIItem, APIItems
 
@@ -32,6 +32,11 @@ class Clients(APIItems):
     async def async_reconnect(self, mac: str) -> None:
         """Force a wireless client to reconnect to the network."""
         data = {"mac": mac, "cmd": "kick-sta"}
+        await self._request("post", URL_CLIENT_STATE_MANAGER, json=data)
+
+    async def async_remove(self, macs: List[str]) -> None:
+        """Make controller forget provided clients."""
+        data = {"macs": macs, "cmd": "forget-sta"}
         await self._request("post", URL_CLIENT_STATE_MANAGER, json=data)
 
 

--- a/aiounifi/clients.py
+++ b/aiounifi/clients.py
@@ -34,7 +34,7 @@ class Clients(APIItems):
         data = {"mac": mac, "cmd": "kick-sta"}
         await self._request("post", URL_CLIENT_STATE_MANAGER, json=data)
 
-    async def async_remove(self, macs: List[str]) -> None:
+    async def remove_clients(self, macs: List[str]) -> None:
         """Make controller forget provided clients."""
         data = {"macs": macs, "cmd": "forget-sta"}
         await self._request("post", URL_CLIENT_STATE_MANAGER, json=data)
@@ -54,6 +54,16 @@ class Client(APIItem):
     """Represents a client network device."""
 
     @property
+    def access_point_mac(self) -> str:
+        """MAC address of access point."""
+        return self.raw.get("ap_mac", "")
+
+    @property
+    def association_time(self) -> Optional[int]:
+        """When was client associated with controller."""
+        return self.raw.get("assoc_time")
+
+    @property
     def blocked(self) -> bool:
         """Is client blocked."""
         return self.raw.get("blocked", False)
@@ -62,6 +72,16 @@ class Client(APIItem):
     def essid(self) -> str:
         """ESSID client is connected to."""
         return self.raw.get("essid", "")
+
+    @property
+    def first_seen(self) -> Optional[int]:
+        """When was client first seen."""
+        return self.raw.get("first_seen")
+
+    @property
+    def fixed_ip(self) -> str:
+        """Fixed IP of client."""
+        return self.raw.get("fixed_ip", "")
 
     @property
     def hostname(self) -> str:
@@ -87,6 +107,11 @@ class Client(APIItem):
     def last_seen(self) -> Optional[int]:
         """When was client last seen."""
         return self.raw.get("last_seen")
+
+    @property
+    def latest_association_time(self) -> Optional[int]:
+        """When was client last associated with controller."""
+        return self.raw.get("latest_assoc_time")
 
     @property
     def mac(self) -> str:

--- a/aiounifi/clients.py
+++ b/aiounifi/clients.py
@@ -85,7 +85,7 @@ class Client(APIItem):
 
     @property
     def fixed_ip(self) -> str:
-        """Fixed IP of client."""
+        """List IP if fixed IP is configured."""
         return self.raw.get("fixed_ip", "")
 
     @property

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2781,6 +2781,7 @@ WIRELESS_CLIENT = {
     "dev_id": 247,
     "dev_id_override": 4,
     "dev_vendor": 11,
+    'device_name': 'Discovery device name',
     "dhcpend_time": 2030,
     "essid": "SSID",
     "fingerprint_override": True,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2656,30 +2656,30 @@ SWITCH_8_PORT = {
 
 DPI_APPS = [
     {
-		"_id": "5f976f62e3c58f018ec7e17d",
-		"apps": [],
-		"blocked": True,
-		"cats": ["4"],
-		"enabled": True,
-		"log": True,
-		"site_id": "5ba29dd4e3c58f026e9d7c38",
-	},
+        "_id": "5f976f62e3c58f018ec7e17d",
+        "apps": [],
+        "blocked": True,
+        "cats": ["4"],
+        "enabled": True,
+        "log": True,
+        "site_id": "5ba29dd4e3c58f026e9d7c38",
+    },
 ]
 
 DPI_GROUPS = [
     {
-		"_id": "5ba29dd8e3c58f026e9d7c4a",
-		"attr_no_delete": True,
-		"attr_hidden_id": "Default",
-		"name": "Default",
-		"site_id": "5ba29dd4e3c58f026e9d7c38",
-	},
+        "_id": "5ba29dd8e3c58f026e9d7c4a",
+        "attr_no_delete": True,
+        "attr_hidden_id": "Default",
+        "name": "Default",
+        "site_id": "5ba29dd4e3c58f026e9d7c38",
+    },
     {
-		"_id": "5f976f4ae3c58f018ec7dff6",
-		"name": "No Media",
-		"site_id": "5ba29dd4e3c58f026e9d7c38",
-		"dpiapp_ids": ["5f976f62e3c58f018ec7e17d"],
-	},
+        "_id": "5f976f4ae3c58f018ec7dff6",
+        "name": "No Media",
+        "site_id": "5ba29dd4e3c58f026e9d7c38",
+        "dpiapp_ids": ["5f976f62e3c58f018ec7e17d"],
+    },
 ]
 
 WLANS = [

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -36,6 +36,7 @@ async def test_clients(mock_aioresponse, unifi_controller):
     assert client.access_point_mac == "80:2a:a8:00:01:02"
     assert client.association_time == 1587753456
     assert client.blocked is False
+    assert client.device_name == "Discovery device name"
     assert client.essid == "SSID"
     assert client.first_seen == 1513271497
     assert client.fixed_ip == "10.0.0.1"
@@ -53,10 +54,14 @@ async def test_clients(mock_aioresponse, unifi_controller):
     assert client.sw_mac == "fc:ec:da:11:22:33"
     assert client.sw_port == 1
     assert client.rx_bytes == 12867114
+    assert client.rx_bytes_r == 326
     assert client.tx_bytes == 52852089
+    assert client.tx_bytes_r == 483
     assert client.uptime == 11904
     assert client.wired_rx_bytes == 0
+    assert client.wired_rx_bytes_r == 0
     assert client.wired_tx_bytes == 0
+    assert client.wired_tx_bytes_r == 0
     assert (
         client.__repr__() == f"<Client Client 1: 00:00:00:00:00:01 {WIRELESS_CLIENT}>"
     )


### PR DESCRIPTION
Relevant background:

https://github.com/wbradmoore/unifi-cleanup/blob/main/unifi-cleanup.py

Thread in hass forums https://community.home-assistant.io/t/unifi-integration-large-number-of-unnamed-devices/154759/23

- https://gist.github.com/shbatm/7a6db684c79b9f9edb509e67da7bd389
- https://gist.github.com/donnlee/00d9bcd7a6b1c5e761be3714d2c1c61a