### PR TITLE
Use x-csrf-token only when remote site provides it with tests

### DIFF
--- a/aiounifi/controller.py
+++ b/aiounifi/controller.py
@@ -111,7 +111,8 @@ class Controller:
             response := self.last_response
         ) is not None and response.status == HTTPStatus.OK:
             self.is_unifi_os = True
-            self.headers = {"x-csrf-token": response.headers.get("x-csrf-token")}
+            if (csrf_token := response.headers.get("x-csrf-token")) is not None:
+                self.headers = {"x-csrf-token": csrf_token}
 
     async def login(self) -> None:
         """Log in to controller."""


### PR DESCRIPTION
This PR includes the commit from #116 rebased to master (thanks @arekm!) with the addition of a new commit with new test cases and fixes to some existing test cases.