### PR TITLE
Add unsupported unifi-device:sync to ignored messages

### DIFF
--- a/aiounifi/controller.py
+++ b/aiounifi/controller.py
@@ -62,7 +62,7 @@ DATA_DPI_GROUP: Final = "dpi_group"
 DATA_DPI_GROUP_REMOVED: Final = "dpi_group_removed"
 
 
-IGNORE_MESSAGES: Final = ("device:update",)
+IGNORE_MESSAGES: Final = ("device:update", "unifi-device:sync")
 
 
 class Controller:

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -975,7 +975,7 @@ async def test_controller_raise_expected_exception(
         await unifi_controller.login()
 
 
-@pytest.mark.parametrize("unsupported_message", ["device:update", "unsupported"])
+@pytest.mark.parametrize("unsupported_message", ["device:update", "unifi-device:sync", "unsupported"])
 async def test_handle_unsupported_events(unifi_controller, unsupported_message):
     """Test controller properly ignores unsupported events."""
     with patch("aiounifi.websocket.WSClient.running"):


### PR DESCRIPTION
Add unsupported `unifi-device:sync` message to ignored messages.

This removes the `Unsupported message type (unifi-device:sync) ...` lines from the debug logging.

Tested with UniFi Network Application version 7.1.66.