### PR TITLE
Add device upgrade command

### DIFF
--- a/aiounifi/interfaces/devices.py
+++ b/aiounifi/interfaces/devices.py
@@ -12,6 +12,8 @@ from .api import APIItems
 
 URL: Final = "/stat/device"
 
+URL_DEVICE_MANAGER: Final = "/cmd/devmgr"
+
 
 class Devices(APIItems):
     """Represents network devices."""
@@ -19,3 +21,8 @@ class Devices(APIItems):
     KEY = "mac"
     path = URL
     item_cls = Device
+
+    async def upgrade(self, mac: str) -> list[dict]:
+        """Upgrade network device."""
+        data = {"mac": mac, "cmd": "upgrade"}
+        return await self.controller.request("post", URL_DEVICE_MANAGER, json=data)

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -734,3 +734,22 @@ async def test_device_switch(mock_aioresponse, unifi_controller, unifi_called_wi
         switch_port_6.__repr__()
         == f"<{switch_port_6.name}: Poe {switch_port_6.poe_enable}>"
     )
+
+
+async def test_device_upgrade(mock_aioresponse, unifi_controller, unifi_called_with):
+    """Test device upgrade command."""
+
+    devices = unifi_controller.devices
+    devices.process_raw([ACCESS_POINT_AC_PRO])
+
+    assert len(devices.values()) == 1
+
+    mock_aioresponse.post(
+        "https://host:8443/api/s/default/cmd/devmgr", payload={}, repeat=True
+    )
+    await devices.upgrade(mac="80:2a:a8:00:01:02")
+    assert unifi_called_with(
+        "post",
+        "/api/s/default/cmd/devmgr",
+        json={"mac": ACCESS_POINT_AC_PRO["mac"], "cmd": "upgrade"},
+    )


### PR DESCRIPTION
This allows the firmware of UniFi network devices to be upgraded by calling `unifi_controller.devices.upgrade(mac="80:2a:a8:00:01:02")`.