### PR TITLE
Support incremental device information updates

### DIFF
--- a/aiounifi/controller.py
+++ b/aiounifi/controller.py
@@ -40,6 +40,7 @@ LOGGER = logging.getLogger(__name__)
 MESSAGE_CLIENT: Final = "sta:sync"
 MESSAGE_CLIENT_REMOVED: Final = "user:delete"
 MESSAGE_DEVICE: Final = "device:sync"
+MESSAGE_DEVICE_UPDATE: Final = "device:update"
 MESSAGE_EVENT: Final = "events"
 MESSAGE_DPI_APP_ADDED: Final = "dpiapp:add"
 MESSAGE_DPI_APP_REMOVED: Final = "dpiapp:delete"
@@ -62,7 +63,7 @@ DATA_DPI_GROUP: Final = "dpi_group"
 DATA_DPI_GROUP_REMOVED: Final = "dpi_group_removed"
 
 
-IGNORE_MESSAGES: Final = ("device:update",)
+IGNORE_MESSAGES: Final = ()
 
 
 class Controller:
@@ -226,6 +227,12 @@ class Controller:
 
         elif message[ATTR_META][ATTR_MESSAGE] == MESSAGE_DEVICE:
             changes[DATA_DEVICE] = self.devices.process_raw(message[ATTR_DATA])
+
+        elif message[ATTR_META][ATTR_MESSAGE] == MESSAGE_DEVICE_UPDATE:
+            self.devices.process_incremental_update(
+                message[ATTR_META][Devices.KEY], message[ATTR_DATA]
+            )
+            changes[DATA_DEVICE] = set()
 
         # DPI App
 

--- a/aiounifi/interfaces/api.py
+++ b/aiounifi/interfaces/api.py
@@ -56,6 +56,16 @@ class APIItems:
         return new_items
 
     @final
+    def process_incremental_update(self, key: int | str, updates: list[dict]) -> None:
+        """Process incremental update data."""
+        if key not in self._items:
+            # Ignore updates for unknown objects
+            return
+
+        for update in updates:
+            self._items[key].incremental_update(update=update)
+
+    @final
     def process_event(self, events: list[UniFiEvent]) -> set:
         """Process event."""
         new_items = set()

--- a/aiounifi/models/api.py
+++ b/aiounifi/models/api.py
@@ -64,6 +64,15 @@ class APIItem:
         for signal_update in self._callbacks + self._subscribers:
             signal_update()
 
+    def incremental_update(self, update: dict) -> None:
+        """Incremental update raw data and signal new data is available."""
+        self.raw.update(update)
+
+        self._source = SOURCE_DATA
+
+        for signal_update in self._callbacks + self._subscribers:
+            signal_update()
+
     def subscribe(self, callback: SubscriptionType) -> Callable:
         """Subscribe to events.
 

--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -41,6 +41,14 @@ class Device(APIItem):
             self.outlets.update(raw.get("outlet_table", []))
         super().update(raw, event)
 
+    def incremental_update(self, update: dict) -> None:
+        """Incremental update raw data and signal new data is available."""
+        if "port_table" in update:
+            self.ports.update(update["port_table"])
+        if "outlet_table" in update:
+            self.outlets.update(update["outlet_table"])
+        super().incremental_update(update)
+
     @property
     def board_revision(self) -> int:
         """Board revision of device."""

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -2,6 +2,7 @@
 
 pytest --cov-report term-missing --cov=aiounifi.clients tests/test_clients.py
 """
+from copy import deepcopy
 
 import pytest
 
@@ -162,7 +163,7 @@ async def test_clients(
     """Test clients class."""
 
     clients = unifi_controller.clients
-    clients.process_raw([raw_data])
+    clients.process_raw([deepcopy(raw_data)])
 
     assert len(clients.items()) == 1
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2,7 +2,7 @@
 
 pytest --cov-report term-missing --cov=aiounifi.controller tests/test_controller.py
 """
-
+from copy import deepcopy
 from unittest.mock import Mock, patch
 
 from aiohttp import client_exceptions
@@ -484,7 +484,7 @@ async def test_clients(mock_aioresponse, unifi_controller):
     # Add client from websocket
     unifi_controller.websocket._data = {
         "meta": {"message": MESSAGE_CLIENT},
-        "data": [WIRELESS_CLIENT],
+        "data": [deepcopy(WIRELESS_CLIENT)],
     }
     unifi_controller.session_handler(SIGNAL_DATA)
     assert len(unifi_controller.clients._items) == 1
@@ -509,7 +509,7 @@ async def test_clients(mock_aioresponse, unifi_controller):
     # Retrieve websocket data
     unifi_controller.websocket._data = {
         "meta": {"message": MESSAGE_CLIENT},
-        "data": [WIRELESS_CLIENT],
+        "data": [deepcopy(WIRELESS_CLIENT)],
     }
     unifi_controller.session_handler(SIGNAL_DATA)
 
@@ -518,7 +518,7 @@ async def test_clients(mock_aioresponse, unifi_controller):
     assert mock_callback.call_count == 1
 
     # Retrieve websocket event
-    unifi_controller.websocket._data = EVENT_WIRELESS_CLIENT_CONNECTED
+    unifi_controller.websocket._data = deepcopy(EVENT_WIRELESS_CLIENT_CONNECTED)
     unifi_controller.session_handler(SIGNAL_DATA)
 
     unifi_controller.callback.assert_called_with(
@@ -562,7 +562,7 @@ async def test_message_client_removed(mock_aioresponse, unifi_controller):
     with patch("aiounifi.websocket.WSClient.running"):
         unifi_controller.start_websocket()
 
-    unifi_controller.websocket._data = MESSAGE_WIRELESS_CLIENT_REMOVED
+    unifi_controller.websocket._data = deepcopy(MESSAGE_WIRELESS_CLIENT_REMOVED)
     unifi_controller.session_handler(SIGNAL_DATA)
     unifi_controller.callback.assert_called_with(
         SIGNAL_DATA, {DATA_CLIENT_REMOVED: {WIRELESS_CLIENT["mac"]}}
@@ -632,7 +632,7 @@ async def test_devices(mock_aioresponse, unifi_controller):
     # Add client from websocket
     unifi_controller.websocket._data = {
         "meta": {"message": MESSAGE_DEVICE},
-        "data": [SWITCH_16_PORT_POE],
+        "data": [deepcopy(SWITCH_16_PORT_POE)],
     }
     unifi_controller.session_handler(SIGNAL_DATA)
     assert len(unifi_controller.devices._items) == 1
@@ -661,7 +661,7 @@ async def test_devices(mock_aioresponse, unifi_controller):
     # Retrieve websocket data
     unifi_controller.websocket._data = {
         "meta": {"message": MESSAGE_DEVICE},
-        "data": [SWITCH_16_PORT_POE],
+        "data": [deepcopy(SWITCH_16_PORT_POE)],
     }
     unifi_controller.session_handler(SIGNAL_DATA)
 
@@ -670,7 +670,7 @@ async def test_devices(mock_aioresponse, unifi_controller):
     assert mock_callback.call_count == 1
 
     # Retrieve websocket event
-    unifi_controller.websocket._data = EVENT_SWITCH_16_CONNECTED
+    unifi_controller.websocket._data = deepcopy(EVENT_SWITCH_16_CONNECTED)
     unifi_controller.session_handler(SIGNAL_DATA)
 
     unifi_controller.callback.assert_called_with(

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -2,6 +2,7 @@
 
 pytest --cov-report term-missing --cov=aiounifi.devices tests/test_devices.py
 """
+from copy import deepcopy
 
 from .fixtures import (
     ACCESS_POINT_AC_PRO,
@@ -26,7 +27,7 @@ async def test_no_devices(mock_aioresponse, unifi_controller, unifi_called_with)
 async def test_device_access_point(unifi_controller):
     """Test device class on an access point."""
     devices = unifi_controller.devices
-    devices.process_raw([ACCESS_POINT_AC_PRO])
+    devices.process_raw([deepcopy(ACCESS_POINT_AC_PRO)])
 
     assert len(devices.values()) == 1
 
@@ -118,7 +119,7 @@ async def test_device_access_point(unifi_controller):
 async def test_device_security_gateway(unifi_controller):
     """Test device class on a security gateway."""
     devices = unifi_controller.devices
-    devices.process_raw([GATEWAY_USG3])
+    devices.process_raw([deepcopy(GATEWAY_USG3)])
 
     assert len(devices.values()) == 1
 
@@ -219,7 +220,7 @@ async def test_device_security_gateway(unifi_controller):
 async def test_device_plug(mock_aioresponse, unifi_controller, unifi_called_with):
     """Test device class on a plug."""
     devices = unifi_controller.devices
-    devices.process_raw([PLUG_UP1])
+    devices.process_raw([deepcopy(PLUG_UP1)])
 
     assert len(devices.values()) == 1
 
@@ -323,7 +324,7 @@ async def test_device_plug(mock_aioresponse, unifi_controller, unifi_called_with
 async def test_device_strip(mock_aioresponse, unifi_controller, unifi_called_with):
     """Test device class on a usp-strip-us."""
     devices = unifi_controller.devices
-    devices.process_raw([STRIP_UP6])
+    devices.process_raw([deepcopy(STRIP_UP6)])
 
     assert len(devices.values()) == 1
 
@@ -502,7 +503,7 @@ async def test_device_strip(mock_aioresponse, unifi_controller, unifi_called_wit
 async def test_device_switch(mock_aioresponse, unifi_controller, unifi_called_with):
     """Test device class on aswitch."""
     devices = unifi_controller.devices
-    devices.process_raw([SWITCH_16_PORT_POE])
+    devices.process_raw([deepcopy(SWITCH_16_PORT_POE)])
 
     assert len(devices.values()) == 1
 

--- a/tests/test_dpi.py
+++ b/tests/test_dpi.py
@@ -2,6 +2,7 @@
 
 pytest --cov-report term-missing --cov=aiounifi.dpi tests/test_dpi.py
 """
+from copy import deepcopy
 
 import pytest
 
@@ -45,7 +46,7 @@ async def test_no_groups(mock_aioresponse, unifi_controller, unifi_called_with):
 async def test_dpi_apps(mock_aioresponse, unifi_controller, unifi_called_with):
     """Test that dpi_apps can create an app."""
     dpi_apps = unifi_controller.dpi_apps
-    dpi_apps.process_raw(DPI_APPS)
+    dpi_apps.process_raw(deepcopy(DPI_APPS))
 
     assert len(dpi_apps.values()) == 1
 
@@ -82,7 +83,7 @@ async def test_dpi_apps(mock_aioresponse, unifi_controller, unifi_called_with):
 async def test_dpi_groups(mock_aioresponse, unifi_controller):
     """Test that dpi_groups can create a group."""
     dpi_groups = unifi_controller.dpi_groups
-    dpi_groups.process_raw(DPI_GROUPS)
+    dpi_groups.process_raw(deepcopy(DPI_GROUPS))
 
     assert len(dpi_groups.values()) == 2
 

--- a/tests/test_wlans.py
+++ b/tests/test_wlans.py
@@ -2,6 +2,7 @@
 
 pytest --cov-report term-missing --cov=aiounifi.wlan tests/test_wlans.py
 """
+from copy import deepcopy
 
 from .fixtures import WLANS
 
@@ -23,7 +24,7 @@ async def test_no_ports(mock_aioresponse, unifi_controller, unifi_called_with):
 async def test_ports(mock_aioresponse, unifi_controller, unifi_called_with):
     """Test that different types of ports work."""
     wlans = unifi_controller.wlans
-    wlans.process_raw(WLANS)
+    wlans.process_raw(deepcopy(WLANS))
 
     assert len(wlans.values()) == 2
 


### PR DESCRIPTION
`device:sync` messages are only send out when a UniFi device is in the _Online_ state.

This implements the `device:update` message so device information is updated when a device is in another state, e.g. _Updating_. This is needed to display up-to-date state of the device in Home Assistant when the device is updating.

The data in `device:update` contains only the fields that are modified since the previous `device:sync` or `device:update` message. This PR adds a new `incremental_update` method to the APIItem class which updates the exiting `raw` data with the newly received information.

This PR also modifies existing tests to deepcopy the fixture data when calling `process_raw` or setting `websocket._data` to prevent accidental modifying the fixture data.

Tested with UniFi Network Application version 7.1.66.