### PR TITLE
set can_retry_login to true by default

### DIFF
--- a/aiounifi/controller.py
+++ b/aiounifi/controller.py
@@ -90,7 +90,7 @@ class Controller:
         self.site = site
         self.sslcontext = sslcontext
         self.callback = callback
-        self.can_retry_login = False
+        self.can_retry_login = True
 
         self.url = f"https://{self.host}:{self.port}"
         self.is_unifi_os = False

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -289,8 +289,6 @@ async def test_unifios_controller_relogin_success(mock_aioresponse, unifi_contro
         content_type="text/html",
         status=401,
     )
-    with pytest.raises(LoginRequired):
-        await unifi_controller.request("get", device_url)
 
     mock_aioresponse.get(
         "https://host:8443",


### PR DESCRIPTION
Session expiry never retries login because can_retry_login is set to False by default.

Fixes #73071 again