### PR TITLE
Also look at `relay_state` when determining whether an outlet is controllable

### DIFF
--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -416,7 +416,7 @@ class Outlet:
     @property
     def has_relay(self) -> bool:
         """Is the outlet controllable."""
-        return self.raw.get("has_relay", False)
+        return self.raw.get("has_relay", False) or "relay_state" in self.raw
 
     @property
     def has_metering(self) -> bool:


### PR DESCRIPTION
On my UniFi UXG, the outlet doesn't have `has_relay`, but it does have `relay_state` and it is controllable (at least through the UniFi Network Application).

[config_entry-unifi-decccc0c9793bfd5f7b3476e1cfecbbb.json.txt](https://github.com/Kane610/aiounifi/files/9612465/config_entry-unifi-decccc0c9793bfd5f7b3476e1cfecbbb.json.txt)
