### PR TITLE
Add message key "alert"

### DIFF
--- a/aiounifi/models/message.py
+++ b/aiounifi/models/message.py
@@ -16,6 +16,7 @@ class MessageKey(enum.Enum):
     "meta": {"rc": "ok", "message": "device:sync"}.
     """
 
+    ALERT = "alert"
     CLIENT = "sta:sync"
     CLIENT_REMOVED = "user:delete"
     DEVICE = "device:sync"


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/77864#issuecomment-1256422516

```
2022-09-20 14:18:20.950 WARNING (MainThread) [aiounifi.models.message] Unsupported message key alert
2022-09-20 14:18:20.955 DEBUG (MainThread) [aiounifi.websocket] {"meta":{"rc":"ok","message":"alert"},"data":[{"category":"SYSTEM","id":"6329af8c95c4e7000xxxxxxx","key":"ADMIN_ACCESS","message":"homeassistant accessed the UniFi Network web application.","message_raw":"{ADMIN} accessed the UniFi Network {PLATFORM} application.","parameters":{"ADMIN":{"id":"5c38b71fd5fb1d4dexxxxxxx","name":"homeassistant"},"PLATFORM":{"name":"web"}},"replace_alerts":[],"severity":"INFO","show_on_dashboard":false,"status":"NEW","target":"ADMIN","timestamp":1663676300928,"title_raw":"Admin Accessed Console","type":"ADMIN_ACCESS"}]}
```