### PR TITLE
Add EVT_XG_OutletPowerCycle event key

### DIFF
--- a/aiounifi/models/event.py
+++ b/aiounifi/models/event.py
@@ -71,6 +71,8 @@ class EventKey(enum.Enum):
     WIRELESS_GUEST_ROAM = "EVT_WG_Roam"
     WIRELESS_GUEST_ROAMRADIO = "EVT_WG_RoamRadio"
 
+    XG_OUTLET_POWER_CYCLE = "EVT_XG_OutletPowerCycle"
+
     IPS_ALERT = "EVT_IPS_IpsAlert"
 
     AD_LOGIN = "EVT_AD_Login"


### PR DESCRIPTION
I am seeing a " Unsupported event key EVT_XG_OutletPowerCycle" log message in Home Assistant. This event is triggered when the UXG Pro cycles its SmartPower outlet (intended for use with an external modem).