### PR TITLE
Add message from WS error to log output

### DIFF
--- a/aiounifi/websocket.py
+++ b/aiounifi/websocket.py
@@ -109,7 +109,7 @@ class WSClient:
                         break
 
                     elif msg.type == aiohttp.WSMsgType.ERROR:
-                        LOGGER.error("AIOHTTP websocket error")
+                        LOGGER.error("AIOHTTP websocket error: '%s'", msg.data)
                         break
 
         except aiohttp.ClientConnectorError:


### PR DESCRIPTION
I was tracking down the cause of unstable UniFi integration in the Home Assistant and couldn't determine the reason from the current logs:
```
2023-01-17 18:20:15.719 ERROR (MainThread) [aiounifi.websocket] AIOHTTP websocket error
2023-01-17 18:20:15.719 WARNING (MainThread) [homeassistant.components.unifi] Lost connection to UniFi Network
2023-01-17 18:20:30.722 INFO (MainThread) [homeassistant.components.unifi] Will try to reconnect to UniFi Network
2023-01-17 18:20:30.905 INFO (MainThread) [homeassistant.components.unifi] Connected to UniFi Network
2023-01-17 18:20:47.061 ERROR (MainThread) [aiounifi.websocket] AIOHTTP websocket error
```

Adding the error message text made it instantly obvious:

```
2023-01-17 18:25:44.696 ERROR (MainThread) [aiounifi.websocket] AIOHTTP websocket error: 'Message size 4417932 exceeds limit 4194304'
2023-01-17 18:25:44.696 DEBUG (MainThread) [aiounifi.websocket] Websocket WebsocketState.DISCONNECTED
2023-01-17 18:25:44.696 WARNING (MainThread) [homeassistant.components.unifi] Lost connection to UniFi Network
```
FTR the huge WS payload shouldn't occur in normal scenarios so there's no need to bother with it in `aiounifi` :)