### PR TITLE
Reset cookie on check_unifi_os

### DIFF
--- a/aiounifi/controller.py
+++ b/aiounifi/controller.py
@@ -93,6 +93,7 @@ class Controller:
             response := self.last_response
         ) is not None and response.status == HTTPStatus.OK:
             self.is_unifi_os = True
+            self.session.cookie_jar.clear_domain(self.host)
         LOGGER.debug("Talking to UniFi OS device: %s", self.is_unifi_os)
 
     async def login(self) -> None:


### PR DESCRIPTION
The Cookie stored when doing the UniFi OS check shouldn't be kept

https://github.com/home-assistant/core/issues/78548