### PR TITLE
ubb_us doesn't support board_rev, it was causing an error

### DIFF
--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -691,7 +691,7 @@ class Device(APIItem):
     @property
     def board_revision(self) -> int:
         """Board revision of device."""
-        return self.raw["board_rev"]
+        return self.raw.get("board_rev",0)
 
     @property
     def considered_lost_at(self) -> int:


### PR DESCRIPTION
This prevents homeassistant from erroring when a Building-to-Building Bridge is part of the network.