### PR TITLE
Fallback if board_rev is not present

### DIFF
--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -348,7 +348,7 @@ class TypedDevice(TypedDict):
     adopted: bool
     antenna_table: list[TypedDeviceAntennaTable]
     architecture: str
-    board_rev: int
+    adoption_completed: int
     bytes: int
     bytes_d: int
     bytes_r: int
@@ -667,9 +667,9 @@ class Device(ApiItem):
     raw: TypedDevice
 
     @property
-    def board_revision(self) -> int:
+    def board_revision(self) -> int | None:
         """Board revision of device."""
-        return self.raw.get("board_rev", "")
+        return self.raw.get("board_rev")
 
     @property
     def considered_lost_at(self) -> int:

--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -349,6 +349,7 @@ class TypedDevice(TypedDict):
     antenna_table: list[TypedDeviceAntennaTable]
     architecture: str
     adoption_completed: int
+    board_rev: NotRequired[int]
     bytes: int
     bytes_d: int
     bytes_r: int

--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -669,7 +669,7 @@ class Device(ApiItem):
     @property
     def board_revision(self) -> int:
         """Board revision of device."""
-        return self.raw["board_rev"]
+        return self.raw.get("board_rev", "")
 
     @property
     def considered_lost_at(self) -> int:


### PR DESCRIPTION
It can happen that some device attributes like the board revision (board_rev) are not present. This happens for example for not yet adopted devices and leads to an error on the calling side.

In terms of the Home Assistant integration this leads to the following error:
````
Logger: homeassistant.components.update
Source: components/unifi/entity.py:62
Integration: Aktualisieren (documentation, issues)
First occurred: 16:24:05 (1 occurrences)
Last logged: 16:24:05

Error while setting up unifi platform for update
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 293, in _async_setup_platform
    await asyncio.shield(task)
  File "/usr/src/homeassistant/homeassistant/components/unifi/update.py", line 91, in async_setup_entry
    controller.register_platform_add_entities(
  File "/usr/src/homeassistant/homeassistant/components/unifi/controller.py", line 225, in register_platform_add_entities
    async_load_entities(description)
  File "/usr/src/homeassistant/homeassistant/components/unifi/controller.py", line 219, in async_load_entities
    async_create_entity(ItemEvent.CHANGED, obj_id)
  File "/usr/src/homeassistant/homeassistant/components/unifi/controller.py", line 212, in async_create_entity
    entity = unifi_platform_entity(obj_id, self, description)
  File "/usr/src/homeassistant/homeassistant/components/unifi/entity.py", line 109, in __init__
    self._attr_device_info = description.device_info_fn(controller.api, obj_id)
  File "/usr/src/homeassistant/homeassistant/components/unifi/entity.py", line 62, in async_device_device_info_fn
    hw_version=str(device.board_revision),
  File "/usr/local/lib/python3.10/site-packages/aiounifi/models/device.py", line 696, in board_revision
    return self.raw["board_rev"]
KeyError: 'board_rev'
````

Although it might be a rare case we could avoid this error. I am happy for a review and feedback if this change is reasonable.