### PR TITLE
Add port support to message class

### DIFF
--- a/aiounifi/models/message.py
+++ b/aiounifi/models/message.py
@@ -32,6 +32,8 @@ class MessageKey(enum.Enum):
     FIREWALL_RULE_ADDED = "firewallrule:add"
     FIREWALL_RULE_UPDATED = "firewallrule:sync"
     NETWORK_CONF_UPDATED = "networkconf:sync"
+    PORT_FORWARD_ADDED = "portforward:add"
+    PORT_FORWARD_UPDATED = "portforward:sync"
     SETTING_UPDATED = "setting:sync"
     SPEED_TEST_UPDATE = "speed-test:update"
     UNIFI_DEVICE = "unifi-device:sync"


### PR DESCRIPTION
This adds port forward to the Message class to avoid a warning when there is Port forwarding settings in the Unifi Network application are added or updated.