### PR TITLE
Change types to match values that come back in API

### DIFF
--- a/aiounifi/models/client.py
+++ b/aiounifi/models/client.py
@@ -25,7 +25,7 @@ class TypedClient(TypedDict):
     authorized: bool
     blocked: bool
     bssid: str
-    bytes_r: int
+    bytes_r: float
     ccq: int
     channel: int
     dev_cat: int
@@ -95,8 +95,8 @@ class TypedClient(TypedDict):
     wired_rx_bytes: int
     wired_tx_packets: int
     wired_rx_packets: int
-    wired_tx_bytes_r: int
-    wired_rx_bytes_r: int
+    wired_tx_bytes_r: float
+    wired_rx_bytes_r: float
 
 
 @dataclass
@@ -291,10 +291,10 @@ class Client(ApiItem):
         return self.raw.get("rx_bytes", 0)
 
     @property
-    def rx_bytes_r(self) -> int:
+    def rx_bytes_r(self) -> float:
         """Bytes recently received over wireless connection."""
-        value = self.raw.get("rx_bytes-r", 0)
-        assert isinstance(value, int)
+        value = self.raw.get("rx_bytes-r", 0.0)
+        assert isinstance(value, float)
         return value
 
     @property
@@ -303,10 +303,10 @@ class Client(ApiItem):
         return self.raw.get("tx_bytes", 0)
 
     @property
-    def tx_bytes_r(self) -> int:
+    def tx_bytes_r(self) -> float:
         """Bytes recently transferred over wireless connection."""
-        value = self.raw.get("tx_bytes-r", 0)
-        assert isinstance(value, int)
+        value = self.raw.get("tx_bytes-r", 0.0)
+        assert isinstance(value, float)
         return value
 
     @property
@@ -342,10 +342,10 @@ class Client(ApiItem):
         return value
 
     @property
-    def wired_rx_bytes_r(self) -> int:
+    def wired_rx_bytes_r(self) -> float:
         """Bytes recently received over wired connection."""
-        value = self.raw.get("wired-rx_bytes-r", 0)
-        assert isinstance(value, int)
+        value = self.raw.get("wired-rx_bytes-r", 0.0)
+        assert isinstance(value, float)
         return value
 
     @property
@@ -356,8 +356,8 @@ class Client(ApiItem):
         return value
 
     @property
-    def wired_tx_bytes_r(self) -> int:
+    def wired_tx_bytes_r(self) -> float:
         """Bytes recently transferred over wired connection."""
-        value = self.raw.get("wired-tx_bytes-r", 0)
-        assert isinstance(value, int)
+        value = self.raw.get("wired-tx_bytes-r", 0.0)
+        assert isinstance(value, float)
         return value


### PR DESCRIPTION
This _might_ be caused by me running Early Access builds of Unifi software/firmware, but when I have the option enabled to collect bandwidth utilization metrics in the Unifi component in HomeAssistant, I get this error:

```
2023-08-09 00:28:49.462 INFO (MainThread) [homeassistant.components.update] Setting up update.unifi
2023-08-09 00:28:49.744 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up unifi platform for sensor
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/helpers/entity_platform.py", line 362, in _async_setup_platform
    await asyncio.shield(task)
  File "/workspaces/core/homeassistant/components/unifi/sensor.py", line 205, in async_setup_entry
    controller.register_platform_add_entities(
  File "/workspaces/core/homeassistant/components/unifi/controller.py", line 230, in register_platform_add_entities
    async_load_entities(description)
  File "/workspaces/core/homeassistant/components/unifi/controller.py", line 209, in async_load_entities
    async_add_unifi_entity(list(api_handler))
  File "/workspaces/core/homeassistant/components/unifi/controller.py", line 200, in async_add_unifi_entity
    [
  File "/workspaces/core/homeassistant/components/unifi/controller.py", line 201, in <listcomp>
    unifi_platform_entity(obj_id, self, description)
  File "/workspaces/core/homeassistant/components/unifi/entity.py", line 138, in __init__
    self.async_initiate_state()
  File "/workspaces/core/homeassistant/components/unifi/entity.py", line 234, in async_initiate_state
    self.async_update_state(ItemEvent.ADDED, self._obj_id)
  File "/workspaces/core/homeassistant/components/unifi/sensor.py", line 223, in async_update_state
    if (value := description.value_fn(self.controller, obj)) != self.native_value:
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/homeassistant/components/unifi/sensor.py", line 50, in async_client_rx_value_fn
    return client.rx_bytes_r / 1000000
           ^^^^^^^^^^^^^^^^^
  File "/home/vscode/.local/lib/python3.11/site-packages/aiounifi/models/client.py", line 297, in rx_bytes_r
    assert isinstance(value, int)
AssertionError
```

Digging in a bit further, i noticed that the values in `client.raw.rx_bytes_r` (and some similar fields, all of which are the `bytes_r` fields) were floats.

This PR addresses this by asserting that the type is a float instead of an int for these fields.

I purposefully left the test alone to ensure that data coming across the wire as ints would continue to parse as expected.

This may be a breaking change downstream, if the calling code assumes that these values are ints.