### PR TITLE
Improve set PoE port mode

### DIFF
--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -646,14 +646,13 @@ class DeviceSetPoePortModeRequest(ApiRequest):
                 break
 
         if not existing_override:
-            portconf_id = device.port_table[port_idx - 1].get("portconf_id", "")
-            device.port_overrides.append(
-                {
-                    "port_idx": port_idx,
-                    "portconf_id": portconf_id,
-                    "poe_mode": mode,
-                }
-            )
+            port_override = {
+                "port_idx": port_idx,
+                "poe_mode": mode,
+            }
+            if portconf_id := device.port_table[port_idx - 1].get("portconf_id"):
+                port_override["portconf_id"] = portconf_id
+            device.port_overrides.append(port_override)
 
         return cls(
             method="put",


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/95207

Unifi has become stricter in what keys provided in requests.

```json
{
    "meta": {"rc": "error", "msg": "api.err.InvalidPayload"},
    "data": [
        {
            "validationError": {"field": "portconf_id", "pattern": "[\\d\\w]+"},
            "rc": "error",
            "msg": "api.err.InvalidValue",
        }
    ],
}
```