### PR TITLE
Improve error logging

### DIFF
--- a/aiounifi/controller.py
+++ b/aiounifi/controller.py
@@ -257,7 +257,9 @@ def _raise_on_error(data: dict[str, Any] | None) -> None:
         return None
 
     if "meta" in data and data["meta"]["rc"] == "error":
+        LOGGER.error(data)
         raise_error(data["meta"]["msg"])
 
     if "errors" in data:
+        LOGGER.error(data)
         raise_error(data["errors"][0])


### PR DESCRIPTION
When debugging PoE issue for 6.5.59 FW I noticed not all error data was printed.