### PR TITLE
Adds missing outlet_ac fields to Device model

### DIFF
--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -754,6 +754,16 @@ class Device(ApiItem):
         return self.raw.get("outlet_overrides", [])
 
     @property
+    def outlet_ac_power_budget(self) -> str | None:
+        """The amount of power available to outlets."""
+        return self.raw.get("outlet_ac_power_budget")
+
+    @property
+    def outlet_ac_power_consumption(self) -> str | None:
+        """The amount of power consumed by all outlets."""
+        return self.raw.get("outlet_ac_power_consumption")
+
+    @property
     def outlet_table(self) -> list[TypedDeviceOutletTable]:
         """List of outlets."""
         return self.raw.get("outlet_table", [])

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -440,6 +440,8 @@ async def test_device_pdu_pro(mock_aioresponse, unifi_controller, unifi_called_w
     assert pdupro.model == "USPPDUP"
     assert pdupro.name == "Main Server Cabinet PDU"
     assert pdupro.next_interval == 56
+    assert pdupro.outlet_ac_power_budget == "1875.000"
+    assert pdupro.outlet_ac_power_consumption == "307.741"
     assert pdupro.outlet_table == [
         {
             "index": 1,


### PR DESCRIPTION
Currently `outlet_ac_power_budget` and `outlet_ac_power_consumption` are only exposed via the raw data. This change exposes these fields as properties on the Device model.