### PR TITLE
Replace async_timeout with asyncio.timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4.5.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.5.0
     hooks:
       - id: mypy
         exclude: ^tests/

--- a/aiounifi/__main__.py
+++ b/aiounifi/__main__.py
@@ -2,12 +2,12 @@
 
 import argparse
 import asyncio
+from asyncio.timeouts import timeout
 import logging
 from ssl import SSLContext
 from typing import TYPE_CHECKING, Callable
 
 import aiohttp
-import async_timeout
 
 import aiounifi
 from aiounifi.controller import Controller
@@ -46,7 +46,7 @@ async def unifi_controller(
     controller.ws_state_callback = callback
 
     try:
-        async with async_timeout.timeout(10):
+        async with timeout(10):
             await controller.check_unifi_os()
             await controller.login()
         return controller

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 aiohttp==3.8.5
-async_timeout==4.0.3
 orjson==3.9.4
 segno==1.5.2

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license="MIT",
     url="https://github.com/Kane610/aiounifi",
     download_url=f"https://github.com/Kane610/aiounifi/archive/v{VERSION}.tar.gz",
-    install_requires=["aiohttp", "async_timeout", "orjson", "segno"],
+    install_requires=["aiohttp", "orjson", "segno"],
     tests_require=["aioresponses", "pytest", "pytest-asyncio", "pytest-aiohttp"],
     keywords=["unifi", "homeassistant"],
     classifiers=["Natural Language :: English", "Programming Language :: Python :: 3"],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import find_packages, setup
 
-MIN_PY_VERSION = "3.10"
+MIN_PY_VERSION = "3.11"
 PACKAGES = find_packages(exclude=["tests", "tests.*"])
 VERSION = "55"
 


### PR DESCRIPTION
Bdraco: async_timeout is now part of python standard lib, we should use asyncio.timeout any place we used async_timeout since it ensures compatibility with the cpython version. async_timeout lags behind a bit and was only recently updated to fully work correctly with cpython 3.11