### PR TITLE
Handle trafficrules not existing on old network apps

### DIFF
--- a/aiounifi/controller.py
+++ b/aiounifi/controller.py
@@ -75,7 +75,10 @@ class Controller:
 
     async def initialize(self) -> None:
         """Load UniFi parameters."""
-        await asyncio.gather(*[update() for update in self.update_handlers])
+        await asyncio.gather(
+            *[update() for update in self.update_handlers],
+            return_exceptions=True,
+        )
 
     async def start_websocket(self) -> None:
         """Start websocket session."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,7 @@ def endpoint_fixture(
     """Use fixtures to mock all endpoints."""
 
     def mock_get_request(
-        path: str, unifi_path: str, payload: list[dict[str, Any]]
+        path: str, unifi_path: str, payload: list[dict[str, Any]] | None
     ) -> None:
         """Register HTTP response mock."""
         url = unifi_path if is_unifi_os else path


### PR DESCRIPTION
Note: improve tests and fixtures to handle other paths than payload i.e. status...

https://github.com/home-assistant/core/issues/103269
https://github.com/Kane610/aiounifi/issues/517