### PR TITLE
Rework error handling

### DIFF
--- a/aiounifi/controller.py
+++ b/aiounifi/controller.py
@@ -78,10 +78,13 @@ class Controller:
 
     async def initialize(self) -> None:
         """Load UniFi parameters."""
-        await asyncio.gather(
+        results = await asyncio.gather(
             *[update() for update in self.update_handlers],
             return_exceptions=True,
         )
+        for result in results:
+            if result is not None:
+                LOGGER.warning("Exception on update %s", result)
 
     async def start_websocket(self) -> None:
         """Start websocket session."""

--- a/aiounifi/errors.py
+++ b/aiounifi/errors.py
@@ -45,17 +45,3 @@ class BadGateway(RequestError):
 
 class TwoFaTokenRequired(AiounifiException):
     """2 factor authentication token required."""
-
-
-ERRORS = {
-    "api.err.LoginRequired": LoginRequired,
-    "api.err.Invalid": Unauthorized,
-    "api.err.NoPermission": NoPermission,
-    "api.err.Ubic2faTokenRequired": TwoFaTokenRequired,
-}
-
-
-def raise_error(error: str) -> None:
-    """Raise error."""
-    cls = ERRORS.get(error, AiounifiException)
-    raise cls(error)

--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -58,7 +58,7 @@ class Connectivity:
 
         response, bytes_data = await self._request("post", url, json=auth)
 
-        if response.content_type.startswith("application/json"):
+        if response.content_type == "application/json":
             data: "TypedApiResponse" = orjson.loads(bytes_data)
             if "meta" in data and data["meta"]["rc"] == "error":
                 LOGGER.error(data)

--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -58,9 +58,9 @@ class Connectivity:
 
         response, bytes_data = await self._request("post", url, json=auth)
 
-        if response.content_type == "application/json":
+        if response.content_type.startswith("application/json"):
             data: "TypedApiResponse" = orjson.loads(bytes_data)
-            if isinstance(data, dict) and data["meta"]["rc"] == "error":
+            if "meta" in data and data["meta"]["rc"] == "error":
                 LOGGER.error(data)
                 raise ERRORS.get(data["meta"]["msg"], AiounifiException)
 

--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -84,7 +84,7 @@ class Connectivity:
                 api_request.method, url, api_request.data
             )
 
-            if response.content_type == api_request.content_type:
+            if response.content_type == "application/json":
                 data = api_request.decode(bytes_data)
 
         except LoginRequired:

--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -47,10 +47,7 @@ class Connectivity:
 
     async def login(self) -> None:
         """Log in to controller."""
-        if self.is_unifi_os:
-            url = f"{self.config.url}/api/auth/login"
-        else:
-            url = f"{self.config.url}/api/login"
+        url = f"{self.config.url}/api{'/auth/login' if self.is_unifi_os else '/login'}"
 
         auth = {
             "username": self.config.username,

--- a/aiounifi/models/api.py
+++ b/aiounifi/models/api.py
@@ -16,8 +16,8 @@ from ..errors import (
 )
 
 ERRORS = {
-    "api.err.LoginRequired": LoginRequired,
     "api.err.Invalid": Unauthorized,
+    "api.err.LoginRequired": LoginRequired,
     "api.err.NoPermission": NoPermission,
     "api.err.Ubic2faTokenRequired": TwoFaTokenRequired,
 }
@@ -37,7 +37,6 @@ class ApiRequest:
     method: str
     path: str
     data: Mapping[str, Any] | None = None
-    content_type = "application/json"
 
     def full_path(self, site: str, is_unifi_os: bool) -> str:
         """Create url to work with a specific controller."""

--- a/aiounifi/models/api.py
+++ b/aiounifi/models/api.py
@@ -37,15 +37,7 @@ class ApiRequest:
 
 @dataclass
 class ApiRequestV2(ApiRequest):
-    """Data class with required properties of a V2 API request.
-
-    We need a way to indicate if, for our model, the v2 API must be called.
-    Therefore an intermediate dataclass 'ApiRequestV2' is made,
-    for passing the correct path and handling errors, so that it mimics v1.
-    This way, we do not need to alter any of the other classes that not
-    need to know about the version of the api used.
-    With the refactoring of the aiounifi-library, this is now possible.
-    """
+    """Data class with required properties of a V2 API request."""
 
     def full_path(self, site: str, is_unifi_os: bool) -> str:
         """Create url to work with a specific controller."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,12 +101,16 @@ def endpoint_fixture(
     system_information_payload: list[dict[str, Any]],
     traffic_route_payload: list[dict[str, Any]],
     traffic_rule_payload: list[dict[str, Any]],
+    traffic_rule_status: int,
     wlan_payload: list[dict[str, Any]],
 ) -> None:
     """Use fixtures to mock all endpoints."""
 
     def mock_get_request(
-        path: str, unifi_path: str, payload: list[dict[str, Any]] | None
+        path: str,
+        unifi_path: str,
+        payload: list[dict[str, Any]],
+        status: int = 200,
     ) -> None:
         """Register HTTP response mock."""
         url = unifi_path if is_unifi_os else path
@@ -115,7 +119,7 @@ def endpoint_fixture(
             if path.startswith("/v2")
             else {"meta": {"rc": "OK"}, "data": payload}
         )
-        mock_aioresponse.get(f"https://host:8443{url}", payload=data)
+        mock_aioresponse.get(f"https://host:8443{url}", payload=data, status=status)
 
     mock_get_request(
         "/api/s/default/stat/sta",
@@ -166,6 +170,7 @@ def endpoint_fixture(
         "/v2/api/site/default/trafficrules",
         "/proxy/network/v2/api/site/default/trafficrules",
         traffic_rule_payload,
+        traffic_rule_status,
     )
     mock_get_request(
         "/api/s/default/rest/wlanconf",
@@ -228,9 +233,9 @@ def system_information_data_fixture() -> list[dict[str, Any]]:
     return []
 
 
-@pytest.fixture(name="wlan_payload")
-def wlan_data_fixture() -> list[dict[str, Any]]:
-    """WLAN data."""
+@pytest.fixture(name="traffic_route_payload")
+def traffic_route_data_fixture() -> list[dict[str, Any]]:
+    """Traffic route data."""
     return []
 
 
@@ -240,7 +245,13 @@ def traffic_rule_data_fixture() -> list[dict[str, Any]]:
     return []
 
 
-@pytest.fixture(name="traffic_route_payload")
-def traffic_route_data_fixture() -> list[dict[str, Any]]:
-    """Traffic route data."""
+@pytest.fixture(name="traffic_rule_status")
+def traffic_rule_status_fixture() -> int:
+    """Traffic rule status."""
+    return 200
+
+
+@pytest.fixture(name="wlan_payload")
+def wlan_data_fixture() -> list[dict[str, Any]]:
+    """WLAN data."""
     return []

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -76,7 +76,11 @@ async def test_login(
             json={"username": "user", "password": "pass", "remember": True},
         )
     else:
-        mock_aioresponse.post("https://host:8443/api/login", payload="")
+        mock_aioresponse.post(
+            "https://host:8443/api/login",
+            payload={"meta": {"rc": "ok"}, "data": []},
+            content_type="application/json",
+        )
         await unifi_controller.connectivity.login()
         assert unifi_called_with(
             "post",
@@ -112,7 +116,10 @@ async def test_controller_login(
         mock_aioresponse.get(
             "https://host:8443", content_type="application/octet-stream", status=302
         )
-        mock_aioresponse.post("https://host:8443/api/login", payload="")
+        mock_aioresponse.post(
+            "https://host:8443/api/login",
+            payload={"meta": {"rc": "ok"}, "data": []},
+        )
         await unifi_controller.login()
         assert unifi_called_with(
             "post",

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -479,7 +479,7 @@ api_request_data = [
 
 
 @pytest.mark.parametrize(("api_request", "path", "input", "expected"), api_request_data)
-async def test_api_request(
+async def test_api_request_error_handling(
     mock_aioresponse,
     unifi_controller: Controller,
     api_request,
@@ -494,7 +494,7 @@ async def test_api_request(
 
 
 @pytest.mark.parametrize(("unwanted_behavior", "expected_exception"), test_data)
-async def test_api_request2(
+async def test_api_request_generic_error_handling(
     mock_aioresponse,
     unifi_controller: Controller,
     unwanted_behavior,

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -399,6 +399,12 @@ async def test_controller_raise_expected_exception(
         await unifi_controller.connectivity.login()
 
 
+@pytest.mark.parametrize("traffic_rule_status", [404])
+async def test_initialize_handles_404(unifi_controller, _mock_endpoints):
+    """Validate initialize does not abort on exception."""
+    await unifi_controller.initialize()
+
+
 @pytest.mark.parametrize(
     "unsupported_message", ["device:update", "unifi-device:sync", "unsupported"]
 )

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -10,6 +10,7 @@ import pytest
 import trustme
 
 from aiounifi import (
+    AiounifiException,
     BadGateway,
     Forbidden,
     LoginRequired,
@@ -21,6 +22,7 @@ from aiounifi import (
     Unauthorized,
 )
 from aiounifi.controller import Controller
+from aiounifi.models.api import ApiRequest, ApiRequestV2
 from aiounifi.models.configuration import Configuration
 
 from .fixtures import LOGIN_UNIFIOS_JSON_RESPONSE, SITE_RESPONSE
@@ -403,6 +405,98 @@ async def test_controller_raise_expected_exception(
 async def test_initialize_handles_404(unifi_controller, _mock_endpoints):
     """Validate initialize does not abort on exception."""
     await unifi_controller.initialize()
+
+
+api_request_data = [
+    (
+        ApiRequest,
+        "/api/s/default",
+        {"payload": {"meta": {"msg": "api.err.LoginRequired", "rc": "error"}}},
+        LoginRequired,
+    ),
+    (
+        ApiRequest,
+        "/api/s/default",
+        {"payload": {"meta": {"msg": "api.err.Invalid", "rc": "error"}}},
+        Unauthorized,
+    ),
+    (
+        ApiRequest,
+        "/api/s/default",
+        {"payload": {"meta": {"msg": "api.err.NoPermission", "rc": "error"}}},
+        NoPermission,
+    ),
+    (
+        ApiRequest,
+        "/api/s/default",
+        {"payload": {"meta": {"msg": "api.err.Ubic2faTokenRequired", "rc": "error"}}},
+        TwoFaTokenRequired,
+    ),
+    (
+        ApiRequest,
+        "/api/s/default",
+        {"payload": {"meta": {"msg": "api.err.OtherError", "rc": "error"}}},
+        AiounifiException,
+    ),
+    (
+        ApiRequestV2,
+        "/v2/api/site/default",
+        {"payload": {"errorCode": 1, "message": "api.err.LoginRequired"}},
+        LoginRequired,
+    ),
+    (
+        ApiRequestV2,
+        "/v2/api/site/default",
+        {"payload": {"errorCode": 2, "message": "api.err.Invalid"}},
+        Unauthorized,
+    ),
+    (
+        ApiRequestV2,
+        "/v2/api/site/default",
+        {"payload": {"errorCode": 3, "message": "api.err.NoPermission"}},
+        NoPermission,
+    ),
+    (
+        ApiRequestV2,
+        "/v2/api/site/default",
+        {"payload": {"errorCode": 4, "message": "api.err.Ubic2faTokenRequired"}},
+        TwoFaTokenRequired,
+    ),
+    (
+        ApiRequestV2,
+        "/v2/api/site/default",
+        {"payload": {"errorCode": 5, "message": "api.err.OtherError"}},
+        AiounifiException,
+    ),
+]
+
+
+@pytest.mark.parametrize(("api_request", "path", "input", "expected"), api_request_data)
+async def test_api_request(
+    mock_aioresponse,
+    unifi_controller: Controller,
+    api_request,
+    path,
+    input,
+    expected,
+):
+    """Verify request raise login required on a 401."""
+    mock_aioresponse.get(f"https://host:8443{path}/test", **input)
+    with pytest.raises(expected):
+        await unifi_controller.connectivity.request(api_request("get", "/test"))
+
+
+@pytest.mark.parametrize(("unwanted_behavior", "expected_exception"), test_data)
+async def test_api_request2(
+    mock_aioresponse,
+    unifi_controller: Controller,
+    unwanted_behavior,
+    expected_exception,
+):
+    """Verify request raise login required on a 401."""
+    mock_aioresponse.get("https://host:8443/api/s/default/test", **unwanted_behavior)
+    with pytest.raises(expected_exception):
+        await unifi_controller.connectivity.request(ApiRequest("get", "/test"))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Replace "raise_error" function with logic in the api_request decode method instead, it will now manage errors differently depending on API version.