### PR TITLE
Add traffic routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ venv.bak/
 .ruff_cache
 
 .vscode/settings.json
+
+#Jetbrains
+.idea

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "charliermarsh.ruff",
+        "ms-python.python"
+    ]
+}

--- a/aiounifi/controller.py
+++ b/aiounifi/controller.py
@@ -18,8 +18,8 @@ from .interfaces.port_forwarding import PortForwarding
 from .interfaces.ports import Ports
 from .interfaces.sites import Sites
 from .interfaces.system_information import SystemInformationHandler
-from .interfaces.traffic_rules import TrafficRules
 from .interfaces.traffic_routes import TrafficRoutes
+from .interfaces.traffic_rules import TrafficRules
 from .interfaces.wlans import Wlans
 from .models.configuration import Configuration
 

--- a/aiounifi/controller.py
+++ b/aiounifi/controller.py
@@ -19,6 +19,7 @@ from .interfaces.ports import Ports
 from .interfaces.sites import Sites
 from .interfaces.system_information import SystemInformationHandler
 from .interfaces.traffic_rules import TrafficRules
+from .interfaces.traffic_routes import TrafficRoutes
 from .interfaces.wlans import Wlans
 from .models.configuration import Configuration
 
@@ -49,6 +50,7 @@ class Controller:
         self.sites = Sites(self)
         self.system_information = SystemInformationHandler(self)
         self.traffic_rules = TrafficRules(self)
+        self.traffic_routes = TrafficRoutes(self)
         self.wlans = Wlans(self)
 
         self.update_handlers: tuple[Callable[[], Coroutine[Any, Any, None]], ...] = (
@@ -61,6 +63,7 @@ class Controller:
             self.sites.update,
             self.system_information.update,
             self.traffic_rules.update,
+            self.traffic_routes.update,
             self.wlans.update,
         )
 

--- a/aiounifi/interfaces/traffic_routes.py
+++ b/aiounifi/interfaces/traffic_routes.py
@@ -1,0 +1,36 @@
+"""Traffic routes as part of a UniFi network."""
+
+from copy import deepcopy
+
+from ..models.api import TypedApiResponse
+from ..models.traffic_route import (
+    TrafficRoute,
+    TrafficRouteEnableRequest,
+    TrafficRouteListRequest,
+)
+from .api_handlers import APIHandler
+
+
+class TrafficRoutes(APIHandler[TrafficRoute]):
+    """Represents TrafficRoutes configurations."""
+
+    obj_id_key = "_id"
+    item_cls = TrafficRoute
+    api_request = TrafficRouteListRequest.create()
+
+    async def enable(self, traffic_route: TrafficRoute) -> TypedApiResponse:
+        """Enable traffic route defined in controller."""
+        return await self.toggle(traffic_route, state=True)
+
+    async def disable(self, traffic_route: TrafficRoute) -> TypedApiResponse:
+        """Disable traffic route defined in controller."""
+        return await self.toggle(traffic_route, state=False)
+
+    async def toggle(self, traffic_route: TrafficRoute, state: bool) -> TypedApiResponse:
+        """Set traffic route - defined in controller - to the desired state."""
+        traffic_route_dict = deepcopy(traffic_route.raw)
+        traffic_route_response = await self.controller.request(
+            TrafficRouteEnableRequest.create(traffic_route_dict, enable=state)
+        )
+        self.process_raw(traffic_route_response.get("data", []))
+        return traffic_route_response

--- a/aiounifi/interfaces/traffic_routes.py
+++ b/aiounifi/interfaces/traffic_routes.py
@@ -26,7 +26,9 @@ class TrafficRoutes(APIHandler[TrafficRoute]):
         """Disable traffic route defined in controller."""
         return await self.toggle(traffic_route, state=False)
 
-    async def toggle(self, traffic_route: TrafficRoute, state: bool) -> TypedApiResponse:
+    async def toggle(
+        self, traffic_route: TrafficRoute, state: bool
+    ) -> TypedApiResponse:
         """Set traffic route - defined in controller - to the desired state."""
         traffic_route_dict = deepcopy(traffic_route.raw)
         traffic_route_response = await self.controller.request(

--- a/aiounifi/models/traffic_route.py
+++ b/aiounifi/models/traffic_route.py
@@ -4,6 +4,15 @@ from dataclasses import dataclass
 from typing import NotRequired, Self, TypedDict
 
 from .api import ApiItem, ApiRequestV2
+
+
+class PortRange(TypedDict):
+    """Port range type definition."""
+
+    port_start: int
+    port_stop: int
+
+
 class IPAddress(TypedDict):
     """IP Address for which traffic route is applicable type definition."""
 
@@ -12,12 +21,15 @@ class IPAddress(TypedDict):
     port_ranges: list[PortRange]
     ports: list[int]
 
+
 class IPRange(TypedDict):
     """IP Range type definition."""
 
     ip_start: str
     ip_stop: str
     ip_version: str
+
+
 class TargetDevice(TypedDict):
     """Target device to which the traffic route applies."""
 
@@ -40,10 +52,7 @@ class TypedTrafficRoute(TypedDict):
     regions: list[str]
     target_devices: list[TargetDevice]
 
-class TypedTrafficRouteUpsert(TypedTrafficRoute):
-    """Traffic route Upsert type definition."""
 
-    next_hop: str
 @dataclass
 class TrafficRouteListRequest(ApiRequestV2):
     """Request object for traffic route list."""
@@ -59,7 +68,7 @@ class TrafficRouteEnableRequest(ApiRequestV2):
     """Request object for traffic route enable."""
 
     @classmethod
-    def create(cls, traffic_route: TypedTrafficRouteUpsert, enable: bool) -> Self:
+    def create(cls, traffic_route: TypedTrafficRoute, enable: bool) -> Self:
         """Create traffic route enable request."""
         traffic_route["enabled"] = enable
         return cls(
@@ -88,11 +97,6 @@ class TrafficRoute(ApiItem):
     def enabled(self) -> bool:
         """Is traffic route enabled."""
         return self.raw["enabled"]
-
-    @property
-    def action(self) -> str:
-        """What action is defined by this traffic route."""
-        return self.raw["action"]
 
     @property
     def matching_target(self) -> str:

--- a/aiounifi/models/traffic_route.py
+++ b/aiounifi/models/traffic_route.py
@@ -1,0 +1,105 @@
+"""Traffic route as part of a UniFi network."""
+
+from dataclasses import dataclass
+from typing import NotRequired, Self, TypedDict
+
+from .api import ApiItem, ApiRequestV2
+class IPAddress(TypedDict):
+    """IP Address for which traffic route is applicable type definition."""
+
+    ip_or_subnet: str
+    ip_version: str
+    port_ranges: list[PortRange]
+    ports: list[int]
+
+class IPRange(TypedDict):
+    """IP Range type definition."""
+
+    ip_start: str
+    ip_stop: str
+    ip_version: str
+class TargetDevice(TypedDict):
+    """Target device to which the traffic route applies."""
+
+    client_mac: NotRequired[str]
+    network_id: NotRequired[str]
+    type: str
+
+
+class TypedTrafficRoute(TypedDict):
+    """Traffic route type definition."""
+
+    _id: str
+    description: str
+    domains: list[str]
+    enabled: bool
+    ip_addresses: list[IPAddress]
+    ip_ranges: list[IPRange]
+    matching_target: str
+    network_id: str
+    regions: list[str]
+    target_devices: list[TargetDevice]
+
+class TypedTrafficRouteUpsert(TypedTrafficRoute):
+    """Traffic route Upsert type definition."""
+
+    next_hop: str
+@dataclass
+class TrafficRouteListRequest(ApiRequestV2):
+    """Request object for traffic route list."""
+
+    @classmethod
+    def create(cls) -> Self:
+        """Create traffic route request."""
+        return cls(method="get", path="/trafficroutes", data=None)
+
+
+@dataclass
+class TrafficRouteEnableRequest(ApiRequestV2):
+    """Request object for traffic route enable."""
+
+    @classmethod
+    def create(cls, traffic_route: TypedTrafficRouteUpsert, enable: bool) -> Self:
+        """Create traffic route enable request."""
+        traffic_route["enabled"] = enable
+        return cls(
+            method="put",
+            path=f"/trafficroutes/{traffic_route['_id']}",
+            data=traffic_route,
+        )
+
+
+class TrafficRoute(ApiItem):
+    """Represent a traffic route configuration."""
+
+    raw: TypedTrafficRoute
+
+    @property
+    def id(self) -> str:
+        """ID of traffic route."""
+        return self.raw["_id"]
+
+    @property
+    def description(self) -> str:
+        """Description given by user to traffic route."""
+        return self.raw["description"]
+
+    @property
+    def enabled(self) -> bool:
+        """Is traffic route enabled."""
+        return self.raw["enabled"]
+
+    @property
+    def action(self) -> str:
+        """What action is defined by this traffic route."""
+        return self.raw["action"]
+
+    @property
+    def matching_target(self) -> str:
+        """What target is matched by this traffic route."""
+        return self.raw["matching_target"]
+
+    @property
+    def target_devices(self) -> list[TargetDevice]:
+        """What target devices are affected by this traffic route."""
+        return self.raw["target_devices"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,7 @@ def endpoint_fixture(
     port_forward_payload: list[dict[str, Any]],
     site_payload: list[dict[str, Any]],
     system_information_payload: list[dict[str, Any]],
+    traffic_route_payload: list[dict[str, Any]],
     traffic_rule_payload: list[dict[str, Any]],
     wlan_payload: list[dict[str, Any]],
 ) -> None:
@@ -155,6 +156,11 @@ def endpoint_fixture(
         "/api/s/default/stat/sysinfo",
         "/proxy/network/api/s/default/stat/sysinfo",
         system_information_payload,
+    )
+    mock_get_request(
+        "/v2/api/site/default/trafficroutes",
+        "/proxy/network/v2/api/site/default/trafficroutes",
+        traffic_route_payload,
     )
     mock_get_request(
         "/v2/api/site/default/trafficrules",
@@ -231,4 +237,10 @@ def wlan_data_fixture() -> list[dict[str, Any]]:
 @pytest.fixture(name="traffic_rule_payload")
 def traffic_rule_data_fixture() -> list[dict[str, Any]]:
     """Traffic rule data."""
+    return []
+
+
+@pytest.fixture(name="traffic_route_payload")
+def traffic_route_data_fixture() -> list[dict[str, Any]]:
+    """Traffic route data."""
     return []

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4629,3 +4629,34 @@ TRAFFIC_RULES = [
         ],
     },
 ]
+
+TRAFFIC_ROUTES = [
+    {
+        "_id": "4547ede96a62654e72293728",
+        "description": "TEST 1",
+        "domains": [],
+        "enabled": False,
+        "ip_addresses": [],
+        "ip_ranges": [],
+        "matching_target": "INTERNET",
+        "network_id": "6547e87f6e34654e72293637",
+        "regions": [],
+        "target_devices": [
+            {"network_id": WIRELESS_CLIENT["network_id"], "type": "NETWORK"},
+            {"client_mac": WIRELESS_CLIENT["mac"], "type": "CLIENT"},
+        ],
+    },
+    {
+        "_id": "754e83e45e62654e722a65ad",
+        "description": "TEST 2",
+        "domains": [],
+        "enabled": True,
+        "ip_addresses": [],
+        "ip_ranges": [],
+        "matching_target": "INTERNET",
+        "network_id": "6547ef4e6e62654e7229376b",
+        "next_hop": "",
+        "regions": [],
+        "target_devices": [{"client_mac": WIRELESS_CLIENT["mac"], "type": "CLIENT"}],
+    },
+]

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -260,6 +260,7 @@ async def test_controller(
     assert unifi_called_with("get", "/api/s/default/rest/portforward")
     assert unifi_called_with("get", "/api/self/sites")
     assert unifi_called_with("get", "/api/s/default/stat/sysinfo")
+    assert unifi_called_with("get", "/v2/api/site/default/trafficroutes")
     assert unifi_called_with("get", "/v2/api/site/default/trafficrules")
     assert unifi_called_with("get", "/api/s/default/rest/wlanconf")
 
@@ -273,6 +274,7 @@ async def test_controller(
     assert len(unifi_controller.port_forwarding.items()) == 0
     assert len(unifi_controller.sites.items()) == 1
     assert len(unifi_controller.system_information.items()) == 0
+    assert len(unifi_controller.traffic_routes.items()) == 0
     assert len(unifi_controller.traffic_rules.items()) == 0
     assert len(unifi_controller.wlans.items()) == 0
 
@@ -313,6 +315,11 @@ async def test_unifios_controller(
     assert unifi_called_with(
         "get",
         "/proxy/network/api/self/sites",
+        headers={"x-csrf-token": "123"},
+    )
+    assert unifi_called_with(
+        "get",
+        "/proxy/network/v2/api/site/default/trafficroutes",
         headers={"x-csrf-token": "123"},
     )
     assert unifi_called_with(

--- a/tests/test_traffic_route.py
+++ b/tests/test_traffic_route.py
@@ -1,0 +1,112 @@
+"""Test traffic routes API for disabling and enabling traffic routes.
+
+pytest --cov-report term-missing --cov=aiounifi.traffic_route tests/test_traffic_routes.py
+"""
+
+import pytest
+
+from aiounifi.models.traffic_route import TrafficRouteEnableRequest
+
+from .fixtures import TRAFFIC_ROUTES, WIRELESS_CLIENT
+
+
+@pytest.mark.parametrize("is_unifi_os", [True])
+@pytest.mark.parametrize("enable", [True, False])
+async def test_traffic_route_enable_request(
+    mock_aioresponse, unifi_controller, unifi_called_with, enable
+):
+    """Test that traffic route can be enabled and disabled."""
+    traffic_route_enabled = TRAFFIC_ROUTES[0]
+    traffic_route_enabled_id = traffic_route_enabled["_id"]
+    traffic_route_disabled = TRAFFIC_ROUTES[1]
+    traffic_route_disabled_id = traffic_route_disabled["_id"]
+
+    traffic_route_id = traffic_route_disabled_id if enable else traffic_route_enabled_id
+    traffic_route = traffic_route_disabled if enable else traffic_route_enabled
+    mock_aioresponse.put(
+        "https://host:8443/proxy/network/v2/api/site/default"
+        + f"/trafficroutes/{traffic_route_id}",
+        payload={},
+    )
+
+    await unifi_controller.request(
+        TrafficRouteEnableRequest.create(traffic_route, enable)
+    )
+
+    traffic_route["enabled"] = enable
+    assert unifi_called_with(
+        "put",
+        f"/proxy/network/v2/api/site/default/trafficroutes/{traffic_route_id}",
+        json=traffic_route,
+    )
+
+
+@pytest.mark.parametrize("traffic_route_payload", [TRAFFIC_ROUTES])
+@pytest.mark.parametrize("is_unifi_os", [True])
+@pytest.mark.parametrize("enable", [True, False])
+async def test_traffic_route_toggle(
+    mock_aioresponse, unifi_controller, _mock_endpoints, enable
+):
+    """Test toggle method can enable and disable a traffic route."""
+    traffic_routes = unifi_controller.traffic_routes
+    await traffic_routes.update()
+
+    traffic_route_id = TRAFFIC_ROUTES[0 if not enable else 1]["_id"]
+
+    mock_aioresponse.put(
+        "https://host:8443/proxy/network/v2/api/site/default"
+        + f"/trafficroutes/{traffic_route_id}",
+        payload={},
+    )
+    await traffic_routes.toggle(traffic_routes[traffic_route_id], enable)
+    assert traffic_routes[traffic_route_id].enabled is enable
+
+
+@pytest.mark.parametrize("traffic_route_payload", [TRAFFIC_ROUTES])
+@pytest.mark.parametrize("is_unifi_os", [True])
+@pytest.mark.parametrize("enable", [True, False])
+async def test_traffic_route_enable_disable(
+    mock_aioresponse, _mock_endpoints, unifi_controller, enable
+):
+    """Test individual methods for enabled and disabled."""
+    traffic_routes = unifi_controller.traffic_routes
+    await traffic_routes.update()
+
+    traffic_route_id = TRAFFIC_ROUTES[0 if not enable else 1]["_id"]
+    traffic_route_call = traffic_routes.disable if not enable else traffic_routes.enable
+
+    mock_aioresponse.put(
+        "https://host:8443/proxy/network/v2/api/site/default"
+        + f"/trafficroutes/{traffic_route_id}",
+        payload={},
+    )
+    await traffic_route_call(traffic_routes[traffic_route_id])
+    assert traffic_routes[traffic_route_id].enabled is enable
+
+
+@pytest.mark.parametrize("is_unifi_os", [True])
+async def test_no_traffic_routes(unifi_controller, _mock_endpoints, unifi_called_with):
+    """Test that no traffic routes also work."""
+    traffic_routes = unifi_controller.traffic_routes
+    await traffic_routes.update()
+    assert unifi_called_with("get", "/proxy/network/v2/api/site/default/trafficroutes")
+    assert len(traffic_routes.values()) == 0
+
+
+@pytest.mark.parametrize("traffic_route_payload", [TRAFFIC_ROUTES])
+async def test_traffic_routes(unifi_controller, _mock_endpoints, unifi_called_with):
+    """Test that we get the expected traffic route."""
+    traffic_routes = unifi_controller.traffic_routes
+    await traffic_routes.update()
+    assert unifi_called_with("get", "/v2/api/site/default/trafficroutes")
+    assert len(traffic_routes.values()) == 2
+
+    traffic_route = traffic_routes["4547ede96a62654e72293728"]
+    assert traffic_route.id == "4547ede96a62654e72293728"
+    assert traffic_route.description == "TEST 1"
+    assert traffic_route.enabled is False
+    assert traffic_route.matching_target == "INTERNET"
+    assert traffic_route.target_devices == [
+        {"network_id": WIRELESS_CLIENT["network_id"], "type": "NETWORK"},
+        {"client_mac": WIRELESS_CLIENT["mac"], "type": "CLIENT"},
+    ]


### PR DESCRIPTION
As mentioned in #522 This adds the ability to list and toggle traffic routes

Very heavily follows the work on traffic rules 

Tested against 

UDM SE v3.1.16
Network 7.5.187


```python
result = await controller.request(TrafficRouteListRequest.create())
LOGGER.info(result)

 ```
```python
route = controller.traffic_routes["_id"]
result = await controller.request(
        TrafficRouteEnableRequest.create(deepcopy(route.raw), False)
    )
LOGGER.info(result)
```