### PR TITLE
Add traffic routes

### DIFF
--- a/aiounifi/controller.py
+++ b/aiounifi/controller.py
@@ -18,6 +18,7 @@ from .interfaces.port_forwarding import PortForwarding
 from .interfaces.ports import Ports
 from .interfaces.sites import Sites
 from .interfaces.system_information import SystemInformationHandler
+from .interfaces.traffic_routes import TrafficRoutes
 from .interfaces.traffic_rules import TrafficRules
 from .interfaces.wlans import Wlans
 from .models.configuration import Configuration
@@ -49,6 +50,7 @@ class Controller:
         self.sites = Sites(self)
         self.system_information = SystemInformationHandler(self)
         self.traffic_rules = TrafficRules(self)
+        self.traffic_routes = TrafficRoutes(self)
         self.wlans = Wlans(self)
 
         self.update_handlers: tuple[Callable[[], Coroutine[Any, Any, None]], ...] = (
@@ -61,6 +63,7 @@ class Controller:
             self.sites.update,
             self.system_information.update,
             self.traffic_rules.update,
+            self.traffic_routes.update,
             self.wlans.update,
         )
 

--- a/aiounifi/interfaces/traffic_routes.py
+++ b/aiounifi/interfaces/traffic_routes.py
@@ -1,0 +1,37 @@
+"""Traffic routes as part of a UniFi network."""
+from copy import deepcopy
+
+from ..models.api import TypedApiResponse
+from ..models.traffic_route import (
+    TrafficRoute,
+    TrafficRouteListRequest,
+    TrafficRouteSaveRequest,
+)
+from .api_handlers import APIHandler
+
+
+class TrafficRoutes(APIHandler[TrafficRoute]):
+    """Represents TrafficRoutes configurations."""
+
+    obj_id_key = "_id"
+    item_cls = TrafficRoute
+    api_request = TrafficRouteListRequest.create()
+
+    async def enable(self, traffic_route: TrafficRoute) -> TypedApiResponse:
+        """Enable traffic route defined in controller."""
+        return await self.save(traffic_route, state=True)
+
+    async def disable(self, traffic_route: TrafficRoute) -> TypedApiResponse:
+        """Disable traffic route defined in controller."""
+        return await self.save(traffic_route, state=False)
+
+    async def save(
+        self, traffic_route: TrafficRoute, state: bool | None = None
+    ) -> TypedApiResponse:
+        """Set traffic route - defined in controller - to the desired state."""
+        traffic_route_dict = deepcopy(traffic_route.raw)
+        traffic_route_response = await self.controller.request(
+            TrafficRouteSaveRequest.create(traffic_route_dict, enable=state)
+        )
+        self.process_raw(traffic_route_response.get("data", []))
+        return traffic_route_response

--- a/aiounifi/models/traffic_route.py
+++ b/aiounifi/models/traffic_route.py
@@ -1,0 +1,149 @@
+"""Traffic routes as part of a UniFi network."""
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import NotRequired, Self, TypedDict
+
+from .api import ApiItem, ApiRequestV2
+
+
+class MatchingTarget(StrEnum):
+    """Possible matching targets for a traffic rule."""
+
+    DOMAINS = "DOMAIN"
+    IP = "IP"
+    INTERNET = "INTERNET"
+    REGION = "REGION"
+
+
+class PortRange(TypedDict):
+    """Port range type definition."""
+
+    port_start: int
+    port_stop: int
+
+
+class IPAddress(TypedDict):
+    """IP Address for which traffic route is applicable type definition."""
+
+    ip_or_subnet: str
+    ip_version: str
+    port_ranges: list[PortRange]
+    ports: list[int]
+
+
+class IPRange(TypedDict):
+    """IP Range type definition."""
+
+    ip_start: str
+    ip_stop: str
+    ip_version: str
+
+
+class TargetDevice(TypedDict):
+    """Target device to which the traffic route applies."""
+
+    client_mac: NotRequired[str]
+    network_id: NotRequired[str]
+    type: str
+
+
+class Domain(TypedDict):
+    """A target domain for a traffic route."""
+
+    domain: str
+    port_ranges: list[PortRange]
+    ports: list[int]
+
+
+class TypedTrafficRoute(TypedDict):
+    """Traffic route type definition."""
+
+    _id: str
+    description: str
+    action: str
+    domains: list[Domain]
+    enabled: bool
+    ip_addresses: list[IPAddress]
+    ip_ranges: list[IPRange]
+    matching_target: MatchingTarget
+    network_ids: list[str]
+    next_hop: str
+    regions: list[str]
+    target_devices: list[TargetDevice]
+
+
+@dataclass
+class TrafficRouteListRequest(ApiRequestV2):
+    """Request object for traffic route list."""
+
+    @classmethod
+    def create(cls) -> Self:
+        """Create traffic route request."""
+        return cls(method="get", path="/trafficroutes", data=None)
+
+
+@dataclass
+class TrafficRouteSaveRequest(ApiRequestV2):
+    """Request object for traffic route save."""
+
+    @classmethod
+    def create(
+        cls, traffic_route: TypedTrafficRoute, enable: bool | None = None
+    ) -> Self:
+        """Create traffic route save request."""
+        if enable is not None:
+            traffic_route["enabled"] = enable
+        return cls(
+            method="put",
+            path=f"/trafficroutes/{traffic_route['_id']}",
+            data=traffic_route,
+        )
+
+
+class TrafficRoute(ApiItem):
+    """Represent a traffic route configuration."""
+
+    raw: TypedTrafficRoute
+
+    @property
+    def id(self) -> str:
+        """ID of traffic route."""
+        return self.raw["_id"]
+
+    @property
+    def description(self) -> str:
+        """Description given by user to traffic route."""
+        return self.raw["description"]
+
+    @property
+    def enabled(self) -> bool:
+        """Is traffic route enabled."""
+        return self.raw["enabled"]
+
+    @property
+    def action(self) -> str:
+        """What action is defined by this traffic route."""
+        return self.raw["action"]
+
+    @property
+    def matching_target(self) -> MatchingTarget:
+        """What target is matched by this traffic route."""
+        return self.raw["matching_target"]
+
+    @property
+    def target_devices(self) -> list[TargetDevice]:
+        """What target devices are affected by this traffic route."""
+        return self.raw["target_devices"]
+
+    @property
+    def ip_addresses(self) -> list[IPAddress]:
+        """What IP addresses are matched against by this traffic route."""
+        return self.raw["ip_addresses"]
+
+    @property
+    def domains(self) -> list[Domain]:
+        """What IP addresses are matched against by this traffic route.
+
+        Note: This requires clients to use the UniFi network devices as their DNS server.
+        """
+        return self.raw["domains"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,7 @@ def endpoint_fixture(
     site_payload: list[dict[str, Any]],
     system_information_payload: list[dict[str, Any]],
     traffic_rule_payload: list[dict[str, Any]],
+    traffic_route_payload: list[dict[str, Any]],
     wlan_payload: list[dict[str, Any]],
 ) -> None:
     """Use fixtures to mock all endpoints."""
@@ -160,6 +161,11 @@ def endpoint_fixture(
         "/v2/api/site/default/trafficrules",
         "/proxy/network/v2/api/site/default/trafficrules",
         traffic_rule_payload,
+    )
+    mock_get_request(
+        "/v2/api/site/default/trafficroutes",
+        "/proxy/network/v2/api/site/default/trafficroutes",
+        traffic_route_payload,
     )
     mock_get_request(
         "/api/s/default/rest/wlanconf",
@@ -231,4 +237,10 @@ def wlan_data_fixture() -> list[dict[str, Any]]:
 @pytest.fixture(name="traffic_rule_payload")
 def traffic_rule_data_fixture() -> list[dict[str, Any]]:
     """Traffic rule data."""
+    return []
+
+
+@pytest.fixture(name="traffic_route_payload")
+def traffic_route_data_fixture() -> list[dict[str, Any]]:
+    """Traffic route data."""
     return []

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4629,3 +4629,61 @@ TRAFFIC_RULES = [
         ],
     },
 ]
+
+TRAFFIC_ROUTES = [
+    {
+        "_id": "6468ecd4c1dd1932ad2f801c",
+        "description": "Test domain rule",
+        "domains": [
+            {"domain": "example.com", "port_ranges": [], "ports": []},
+        ],
+        "enabled": False,
+        "ip_addresses": [],
+        "ip_ranges": [],
+        "matching_target": "DOMAIN",
+        "network_id": "5a32aa4ee4b047ede36a85a8",
+        "regions": [],
+        "target_devices": [
+            {
+                "network_id": WIRELESS_CLIENT["network_id"],
+                "type": "NETWORK",
+            },
+        ],
+    },
+    {
+        "_id": "655565af1e1c2754a39388a4",
+        "description": "Test all internet rule",
+        "domains": [],
+        "enabled": False,
+        "ip_addresses": [],
+        "ip_ranges": [],
+        "matching_target": "INTERNET",
+        "network_id": "5a32aa4ee4b047ede36a85a8",
+        "next_hop": "",
+        "regions": [],
+        "target_devices": [
+            {"network_id": WIRELESS_CLIENT["network_id"], "type": "NETWORK"}
+        ],
+    },
+    {
+        "_id": "655566f91e1c2754a393892c",
+        "description": "Test IP rule",
+        "domains": [],
+        "enabled": True,
+        "ip_addresses": [
+            {
+                "ip_or_subnet": "1.1.1.1",
+                "ip_version": "v4",
+                "port_ranges": [],
+                "ports": [],
+            },
+        ],
+        "ip_ranges": [],
+        "matching_target": "IP",
+        "network_id": "5a32aa4ee4b047ede36a85a8",
+        "regions": [],
+        "target_devices": [
+            {"network_id": WIRELESS_CLIENT["network_id"], "type": "NETWORK"}
+        ],
+    },
+]

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -261,6 +261,7 @@ async def test_controller(
     assert unifi_called_with("get", "/api/self/sites")
     assert unifi_called_with("get", "/api/s/default/stat/sysinfo")
     assert unifi_called_with("get", "/v2/api/site/default/trafficrules")
+    assert unifi_called_with("get", "/v2/api/site/default/trafficroutes")
     assert unifi_called_with("get", "/api/s/default/rest/wlanconf")
 
     assert len(unifi_controller.clients.items()) == 0
@@ -274,6 +275,7 @@ async def test_controller(
     assert len(unifi_controller.sites.items()) == 1
     assert len(unifi_controller.system_information.items()) == 0
     assert len(unifi_controller.traffic_rules.items()) == 0
+    assert len(unifi_controller.traffic_routes.items()) == 0
     assert len(unifi_controller.wlans.items()) == 0
 
 
@@ -318,6 +320,11 @@ async def test_unifios_controller(
     assert unifi_called_with(
         "get",
         "/proxy/network/v2/api/site/default/trafficrules",
+        headers={"x-csrf-token": "123"},
+    )
+    assert unifi_called_with(
+        "get",
+        "/proxy/network/v2/api/site/default/trafficroutes",
         headers={"x-csrf-token": "123"},
     )
     assert unifi_called_with(

--- a/tests/test_traffic_routes.py
+++ b/tests/test_traffic_routes.py
@@ -1,0 +1,111 @@
+"""Test traffic routes API for updateing as well as disabling and enabling traffic routes.
+
+pytest --cov-report term-missing --cov=aiounifi.traffic_route tests/test_traffic_routes.py
+"""
+import pytest
+
+from aiounifi.models.traffic_route import TrafficRouteSaveRequest
+
+from .fixtures import TRAFFIC_RULES, WIRELESS_CLIENT
+
+
+@pytest.mark.parametrize("is_unifi_os", [True])
+@pytest.mark.parametrize("enable", [True, False])
+async def test_traffic_route_enable_request(
+    mock_aioresponse, unifi_controller, unifi_called_with, enable
+):
+    """Test that traffic route can be enabled and disabled."""
+    traffic_route_enabled = TRAFFIC_RULES[0]
+    traffic_route_enabled_id = traffic_route_enabled["_id"]
+    traffic_route_disabled = TRAFFIC_RULES[1]
+    traffic_route_disabled_id = traffic_route_disabled["_id"]
+
+    traffic_route_id = traffic_route_disabled_id if enable else traffic_route_enabled_id
+    traffic_route = traffic_route_disabled if enable else traffic_route_enabled
+    mock_aioresponse.put(
+        "https://host:8443/proxy/network/v2/api/site/default"
+        + f"/trafficroutes/{traffic_route_id}",
+        payload={},
+    )
+
+    await unifi_controller.request(
+        TrafficRouteSaveRequest.create(traffic_route, enable)
+    )
+
+    traffic_route["enabled"] = enable
+    assert unifi_called_with(
+        "put",
+        f"/proxy/network/v2/api/site/default/trafficroutes/{traffic_route_id}",
+        json=traffic_route,
+    )
+
+
+@pytest.mark.parametrize("traffic_route_payload", [TRAFFIC_RULES])
+@pytest.mark.parametrize("is_unifi_os", [True])
+@pytest.mark.parametrize("enable", [True, False])
+async def test_traffic_route_save(
+    mock_aioresponse, unifi_controller, _mock_endpoints, enable
+):
+    """Test save method can enable and disable a traffic route."""
+    traffic_routes = unifi_controller.traffic_routes
+    await traffic_routes.update()
+
+    traffic_route_id = TRAFFIC_RULES[0 if not enable else 1]["_id"]
+
+    mock_aioresponse.put(
+        "https://host:8443/proxy/network/v2/api/site/default"
+        + f"/trafficroutes/{traffic_route_id}",
+        payload={},
+    )
+    await traffic_routes.save(traffic_routes[traffic_route_id], enable)
+    assert traffic_routes[traffic_route_id].enabled is enable
+
+
+@pytest.mark.parametrize("traffic_route_payload", [TRAFFIC_RULES])
+@pytest.mark.parametrize("is_unifi_os", [True])
+@pytest.mark.parametrize("enable", [True, False])
+async def test_traffic_route_enable_disable(
+    mock_aioresponse, unifi_controller, _mock_endpoints, enable
+):
+    """Test individual methods for enabled and disabled."""
+    traffic_routes = unifi_controller.traffic_routes
+    await traffic_routes.update()
+
+    traffic_route_id = TRAFFIC_RULES[0 if not enable else 1]["_id"]
+    traffic_route_call = traffic_routes.disable if not enable else traffic_routes.enable
+
+    mock_aioresponse.put(
+        "https://host:8443/proxy/network/v2/api/site/default"
+        + f"/trafficroutes/{traffic_route_id}",
+        payload={},
+    )
+    await traffic_route_call(traffic_routes[traffic_route_id])
+    assert traffic_routes[traffic_route_id].enabled is enable
+
+
+@pytest.mark.parametrize("is_unifi_os", [True])
+async def test_no_traffic_routes(unifi_controller, _mock_endpoints, unifi_called_with):
+    """Test that no traffic routes also work."""
+    traffic_routes = unifi_controller.traffic_routes
+    await traffic_routes.update()
+    assert unifi_called_with("get", "/proxy/network/v2/api/site/default/trafficroutes")
+    assert len(traffic_routes.values()) == 0
+
+
+@pytest.mark.parametrize("traffic_route_payload", [TRAFFIC_RULES])
+async def test_traffic_routes(unifi_controller, _mock_endpoints, unifi_called_with):
+    """Test that we get the expected traffic route."""
+    traffic_routes = unifi_controller.traffic_routes
+    await traffic_routes.update()
+    assert unifi_called_with("get", "/v2/api/site/default/trafficroutes")
+    assert len(traffic_routes.values()) == 2
+
+    traffic_route = traffic_routes["6452cd9b859d5b11aa002ea1"]
+    assert traffic_route.id == "6452cd9b859d5b11aa002ea1"
+    assert traffic_route.description == "Test 1"
+    assert traffic_route.enabled is False
+    assert traffic_route.action == "BLOCK"
+    assert traffic_route.matching_target == "INTERNET"
+    assert traffic_route.target_devices == [
+        {"client_mac": WIRELESS_CLIENT["mac"], "type": "CLIENT"}
+    ]


### PR DESCRIPTION
Adds support for reading, enabling, disabling, as well as generally updating Traffic Routes.

I based this off the PR #409

One thing I wasn't sure about was what fields I should make properties vs leaving as accessible via `.raw`. I made a few of the ones that I plan to use, but I'm happy to just make them all accessible that way.