### PR TITLE
feat: add typing for Speedtest Status

### DIFF
--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -852,8 +852,7 @@ class Device(ApiItem):
     @property
     def speedtest_status(self) -> TypedDeviceSpeedtestStatus | None:
         """Speedtest status."""
-        value = self.raw.get("speedtest-status")
-        if value is None:
+        if (value := self.raw.get("speedtest-status")) is None:
             return None
         return cast(TypedDeviceSpeedtestStatus, value)
 

--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from enum import IntEnum
 import logging
-from typing import Any, NotRequired, Self, TypedDict
+from typing import Any, NotRequired, Self, TypedDict, cast
 
 from .api import ApiItem, ApiRequest
 
@@ -338,6 +338,20 @@ class TypedDeviceWlanOverrides(TypedDict):
     wlan_id: str
 
 
+class TypedDeviceSpeedtestStatus(TypedDict):
+    """Device speedtest status type definition."""
+
+    latency: int
+    rundate: int
+    runtime: int
+    status_download: int
+    status_ping: int
+    status_summary: int
+    status_upload: int
+    xput_download: float
+    xput_upload: float
+
+
 class TypedDevice(TypedDict):
     """Device type definition."""
 
@@ -448,6 +462,7 @@ class TypedDevice(TypedDict):
     serial: str
     site_id: str
     spectrum_scanning: bool
+    speedtest_status: TypedDeviceSpeedtestStatus | None
     ssh_session_table: list  # type: ignore[type-arg]
     start_connected_millis: int
     start_disconnected_millis: int
@@ -833,6 +848,14 @@ class Device(ApiItem):
     def port_table(self) -> list[TypedDevicePortTable]:
         """List of ports and data."""
         return self.raw.get("port_table", [])
+
+    @property
+    def speedtest_status(self) -> TypedDeviceSpeedtestStatus | None:
+        """Speedtest status."""
+        value = self.raw.get("speedtest-status")
+        if value is None:
+            return None
+        return cast(TypedDeviceSpeedtestStatus, value)
 
     @property
     def state(self) -> DeviceState:

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -118,6 +118,7 @@ test_data = [
             "uptime": 3971869,
             "user_num_sta": 20,
             "wlan_overrides": [],
+            "speedtest_status": GATEWAY_USG3["speedtest-status"],
         },
     ),
     (


### PR DESCRIPTION
I'm not fully sure whether this is the right way to add this, but it'd be really nice to have these values typed so that they could be added to Home Assistant (rather than having to use `speedtest.net` as well). 🙂