### PR TITLE
Compress websocket data

### DIFF
--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -168,7 +168,7 @@ class Connectivity:
 
         try:
             async with self.config.session.ws_connect(
-                url, ssl=self.config.ssl_context, heartbeat=15
+                url, ssl=self.config.ssl_context, heartbeat=15, compress=9
             ) as websocket_connection:
                 LOGGER.debug("Connected to UniFi websocket %s", url)
 

--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -168,7 +168,7 @@ class Connectivity:
 
         try:
             async with self.config.session.ws_connect(
-                url, ssl=self.config.ssl_context, heartbeat=15, compress=9
+                url, ssl=self.config.ssl_context, heartbeat=15, compress=12
             ) as websocket_connection:
                 LOGGER.debug("Connected to UniFi websocket %s", url)
 


### PR DESCRIPTION
@bdraco suggests link saturation might be the cause of some disconnects, compressing websocket might alleviate this.

https://docs.aiohttp.org/en/stable/client_reference.html

compress ([int](https://docs.python.org/3/library/functions.html#int)) –
Enable Per-Message Compress Extension support.
0 for disable, 9 to 15 for window bit support. Default value is 0.
New in version 2.3.

According to https://websockets.readthedocs.io/en/stable/topics/compression.html a good value is 12