### PR TITLE
Only use HTTPS if ssl_context exists

### DIFF
--- a/aiounifi/models/configuration.py
+++ b/aiounifi/models/configuration.py
@@ -23,4 +23,8 @@ class Configuration:
     @property
     def url(self) -> str:
         """Represent console path."""
-        return f"https://{self.host}:{self.port}"
+        return (
+            f"https://{self.host}:{self.port}"
+            if self.ssl_context
+            else f"http://{self.host}:{self.port}"
+        )


### PR DESCRIPTION
Despite being able to set a SSL context the URI used to connect to the controller is hardcoded to use HTTPS. Not every controller runs on HTTPS so connecting will always fail with the error

> 2024-03-15 21:17:48.964 ERROR (MainThread) [homeassistant.components.unifi] Error connecting to the UniFi Network at uinet: Error requesting data from https://host:8443: Cannot connect to host host:8443 ssl:False [Name has no usable address]

This feels like an oversight so my PR fixes this.