### PR TITLE
Re-initialize variable to default state for each attempt

### DIFF
--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -48,6 +48,7 @@ class Connectivity:
 
     async def check_unifi_os(self) -> None:
         """Check if controller is running UniFi OS."""
+        self.is_unifi_os = False
         response, _ = await self._request("get", self.config.url, allow_redirects=False)
         if response.status == HTTPStatus.OK:
             self.is_unifi_os = True


### PR DESCRIPTION
Fixes the behavior I saw here https://github.com/home-assistant/core/issues/114196

My guess is something with newer network controller versions changed (8.1.XX), and this check isn't perfect and the request returns sometimes at startup. We could tweak this check or just reset the variable on each attempt and allow the websocket connection to be attempted/fail independently of logging in after this step of the setup process