### PR TITLE
Add EVT_SW_DetectRogueDHCP

### DIFF
--- a/aiounifi/models/event.py
+++ b/aiounifi/models/event.py
@@ -56,6 +56,7 @@ class EventKey(enum.Enum):
     SWITCH_CONFIGURED = "EVT_SW_Configured"
     SWITCH_CONNECTED = "EVT_SW_Connected"
     SWITCH_DELETED = "EVT_SW_Deleted"
+    SWITCH_DETECT_ROGUE_DHCP = "EVT_SW_DetectRogueDHCP"
     SWITCH_DISCOVERED_PENDING = "EVT_SW_DiscoveredPending"
     SWITCH_LOST_CONTACT = "EVT_SW_Lost_Contact"
     SWITCH_OVERHEAT = "EVT_SW_Overheat"


### PR DESCRIPTION
Avoids a warning for events:

`WARNING (MainThread) [aiounifi.models.event] Unsupported event {'sw': 'aa:bb:cc:dd:ee:ff', 'sw_name': '<switch name>', 'ip': '192.168.1.1', 'mac': 'aa:bb:cc:dd:ee:ff', 'port': 5, 'vlan': 1, 'sw_model': 'US8P60', 'sw_displayName': '<switch name>', 'key': 'EVT_SW_DetectRogueDHCP', 'subsystem': 'lan', 'is_negative': True, 'site_id': '<site id>', 'time': 1711923944000, 'datetime': '2024-03-31T22:25:44Z', 'msg': 'Switch[aa:bb:cc:dd:ee:ff] detected rogue dhcp server 192.168.1.1 [aa:bb:cc:dd:ee:ff] on port 5 vlan 1', '_id': '<id>'}`