### PR TITLE
Handle login non JSON response

### DIFF
--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -74,7 +74,7 @@ class Connectivity:
                 LOGGER.error("Login failed '%s'", data)
                 raise ERRORS.get(data["meta"]["msg"], AiounifiException)
         else:
-            LOGGER.error("Login Failed not JSON: '%s'", bytes_data)
+            LOGGER.debug("Login Failed not JSON: '%s'", bytes_data)
             raise RequestError("Login Failed: Host starting up")
   
         if (

--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -73,15 +73,17 @@ class Connectivity:
             if "meta" in data and data["meta"]["rc"] == "error":
                 LOGGER.error("Login failed '%s'", data)
                 raise ERRORS.get(data["meta"]["msg"], AiounifiException)
+
+        elif response.content_type == "text/html":
+            LOGGER.debug("Login Failed not JSON: '%s'", bytes_data)
+            raise RequestError("Login Failed: Host starting up")
+
         if (
             response.status == HTTPStatus.OK
             and (csrf_token := response.headers.get("x-csrf-token")) is not None
         ):
             self.headers["x-csrf-token"] = csrf_token
 
-        elif response.content_type == "text/html":
-            LOGGER.debug("Login Failed not JSON: '%s'", bytes_data)
-            raise RequestError("Login Failed: Host starting up")
 
 
         self.can_retry_login = True

--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -73,15 +73,16 @@ class Connectivity:
             if "meta" in data and data["meta"]["rc"] == "error":
                 LOGGER.error("Login failed '%s'", data)
                 raise ERRORS.get(data["meta"]["msg"], AiounifiException)
-        else:
-            LOGGER.debug("Login Failed not JSON: '%s'", bytes_data)
-            raise RequestError("Login Failed: Host starting up")
-  
         if (
             response.status == HTTPStatus.OK
             and (csrf_token := response.headers.get("x-csrf-token")) is not None
         ):
             self.headers["x-csrf-token"] = csrf_token
+
+        elif response.content_type == "text/html":
+            LOGGER.debug("Login Failed not JSON: '%s'", bytes_data)
+            raise RequestError("Login Failed: Host starting up")
+
 
         self.can_retry_login = True
         LOGGER.debug("Logged in to UniFi %s", url)

--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -73,7 +73,10 @@ class Connectivity:
             if "meta" in data and data["meta"]["rc"] == "error":
                 LOGGER.error("Login failed '%s'", data)
                 raise ERRORS.get(data["meta"]["msg"], AiounifiException)
-
+        else:
+            LOGGER.error("Login Failed not JSON: '%s'", bytes_data)
+            raise RequestError("Login Failed: Host starting up")
+  
         if (
             response.status == HTTPStatus.OK
             and (csrf_token := response.headers.get("x-csrf-token")) is not None

--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -84,8 +84,6 @@ class Connectivity:
         ):
             self.headers["x-csrf-token"] = csrf_token
 
-
-
         self.can_retry_login = True
         LOGGER.debug("Logged in to UniFi %s", url)
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -349,6 +349,7 @@ async def test_unifios_controller_login_html_response(
         "https://host:8443",
         content_type="text/html",
     )
+    await unifi_controller.connectivity.check_unifi_os()
 
     mock_aioresponse.post(
         "https://host:8443/api/auth/login",

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -344,17 +344,10 @@ async def test_unifios_controller(
 async def test_unifios_controller_login_html_response(
     mock_aioresponse, unifi_controller, unifi_called_with
 ):
-    """Test controller communicating with a UniFi OS controller without csrf token."""
+    """Test controller communicating with a UniFi OS controller text/html response."""
     mock_aioresponse.get(
         "https://host:8443",
         content_type="text/html",
-    )
-    await unifi_controller.connectivity.check_unifi_os()
-    assert unifi_controller.connectivity.is_unifi_os
-    assert unifi_called_with(
-        "get",
-        "",
-        allow_redirects=False,
     )
 
     mock_aioresponse.post(

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -341,6 +341,7 @@ async def test_unifios_controller(
         headers={"x-csrf-token": "123"},
     )
 
+
 async def test_unifios_controller_login_html_response(
     mock_aioresponse, unifi_controller, unifi_called_with
 ):
@@ -358,6 +359,7 @@ async def test_unifios_controller_login_html_response(
     )
     with pytest.raises(RequestError):
         await unifi_controller.connectivity.login()
+
 
 async def test_unifios_controller_no_csrf_token(
     mock_aioresponse, unifi_controller, unifi_called_with

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -341,6 +341,29 @@ async def test_unifios_controller(
         headers={"x-csrf-token": "123"},
     )
 
+async def test_unifios_controller_login_html_response(
+    mock_aioresponse, unifi_controller, unifi_called_with
+):
+    """Test controller communicating with a UniFi OS controller without csrf token."""
+    mock_aioresponse.get(
+        "https://host:8443",
+        content_type="text/html",
+    )
+    await unifi_controller.connectivity.check_unifi_os()
+    assert unifi_controller.connectivity.is_unifi_os
+    assert unifi_called_with(
+        "get",
+        "",
+        allow_redirects=False,
+    )
+
+    mock_aioresponse.post(
+        "https://host:8443/api/auth/login",
+        payload="Login Failed: Host starting up",
+        content_type="text/html",
+    )
+    with pytest.raises(RequestError):
+        await unifi_controller.connectivity.login()
 
 async def test_unifios_controller_no_csrf_token(
     mock_aioresponse, unifi_controller, unifi_called_with


### PR DESCRIPTION
This handles the non JSON response and causes retries until the host is "alive"
There may be a better way to handle things.  I selected .debug for the log as it "spams" the log file with errors during a "normal" startup