### PR TITLE
Add types for update_stats

### DIFF
--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -330,17 +330,17 @@ class TypedDeviceUplink(TypedDict):
     uplink_remote_port: int
 
 
-class TypedDeviceUpdtimeStats(TypedDict):
-    """Device uptime stats type definition."""
-
-    WAN: TypedDeviceUpdtimeStatsWan
-    WAN2: TypedDeviceUpdtimeStatsWan
-
-
-class TypedDeviceUpdtimeStatsWan(TypedDict):
+class TypedDeviceUptimeStatsWan(TypedDict):
     """Device uptime stats wan type definition."""
 
     monitors: list[dict[str, Any]]
+
+
+class TypedDeviceUptimeStats(TypedDict):
+    """Device uptime stats type definition."""
+
+    WAN: TypedDeviceUptimeStatsWan
+    WAN2: TypedDeviceUptimeStatsWan
 
 
 class TypedDeviceWlanOverrides(TypedDict):
@@ -502,7 +502,7 @@ class TypedDevice(TypedDict):
     uplink_depth: int
     uplink_table: list  # type: ignore[type-arg]
     uptime: int
-    uptime_stats: TypedDeviceUpdtimeStats
+    uptime_stats: TypedDeviceUptimeStats
     user_num_sta: int
     user_wlan_num_sta: int
     usg_caps: int
@@ -986,7 +986,7 @@ class Device(ApiItem):
         return self.raw.get("uptime", 0)
 
     @property
-    def uptime_stats(self) -> TypedDeviceUpdtimeStats | None:
+    def uptime_stats(self) -> TypedDeviceUptimeStats | None:
         """Uptime statistics."""
         data = self.raw["uptime_stats"]
 

--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -334,7 +334,7 @@ class TypedDeviceUptimeStatsWanMonitor(TypedDict):
     """Device uptime stats wan monitor type definition."""
 
     availability: float
-    latency_average: int
+    latency_average: NotRequired[int]
     target: str
     type: str
 

--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -334,6 +334,8 @@ class TypedDeviceUpdtimeStats(TypedDict):
     """Device uptime stats type definition."""
 
     WAN: TypedDeviceUpdtimeStatsWan
+    WAN2: TypedDeviceUpdtimeStatsWan
+
 
 class TypedDeviceUpdtimeStatsWan(TypedDict):
     """Device uptime stats wan type definition."""

--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -511,7 +511,7 @@ class TypedDevice(TypedDict):
     uplink_depth: int
     uplink_table: list  # type: ignore[type-arg]
     uptime: int
-    uptime_stats: TypedDeviceUptimeStats
+    uptime_stats: TypedDeviceUptimeStats | None
     user_num_sta: int
     user_wlan_num_sta: int
     usg_caps: int

--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -330,10 +330,19 @@ class TypedDeviceUplink(TypedDict):
     uplink_remote_port: int
 
 
+class TypedDeviceUptimeStatsWanMonitor(TypedDict):
+    """Device uptime stats wan monitor type definition."""
+
+    availability: float
+    latency_average: int
+    target: str
+    type: str
+
+
 class TypedDeviceUptimeStatsWan(TypedDict):
     """Device uptime stats wan type definition."""
 
-    monitors: list[dict[str, Any]]
+    monitors: list[TypedDeviceUptimeStatsWanMonitor]
 
 
 class TypedDeviceUptimeStats(TypedDict):

--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -988,7 +988,7 @@ class Device(ApiItem):
     @property
     def uptime_stats(self) -> TypedDeviceUptimeStats | None:
         """Uptime statistics."""
-        data = self.raw["uptime_stats"]
+        return self.raw.get("uptime_stats")
 
     @property
     def user_num_sta(self) -> int:

--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -333,12 +333,13 @@ class TypedDeviceUplink(TypedDict):
 class TypedDeviceUpdtimeStats(TypedDict):
     """Device uptime stats type definition."""
 
-    wan: TypedDeviceUpdtimeStatsWan
+    WAN: TypedDeviceUpdtimeStatsWan
 
 class TypedDeviceUpdtimeStatsWan(TypedDict):
     """Device uptime stats wan type definition."""
 
     monitors: list[dict[str, Any]]
+
 
 class TypedDeviceWlanOverrides(TypedDict):
     """Device wlan overrides type definition."""

--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -330,6 +330,16 @@ class TypedDeviceUplink(TypedDict):
     uplink_remote_port: int
 
 
+class TypedDeviceUpdtimeStats(TypedDict):
+    """Device uptime stats type definition."""
+
+    wan: TypedDeviceUpdtimeStatsWan
+
+class TypedDeviceUpdtimeStatsWan(TypedDict):
+    """Device uptime stats wan type definition."""
+
+    monitors: list[dict[str, Any]]
+
 class TypedDeviceWlanOverrides(TypedDict):
     """Device wlan overrides type definition."""
 
@@ -489,6 +499,7 @@ class TypedDevice(TypedDict):
     uplink_depth: int
     uplink_table: list  # type: ignore[type-arg]
     uptime: int
+    uptime_stats: TypedDeviceUpdtimeStats
     user_num_sta: int
     user_wlan_num_sta: int
     usg_caps: int
@@ -970,6 +981,11 @@ class Device(ApiItem):
     def uptime(self) -> int:
         """Uptime of device."""
         return self.raw.get("uptime", 0)
+
+    @property
+    def uptime_stats(self) -> TypedDeviceUpdtimeStats | None:
+        """Uptime statistics."""
+        data = self.raw["uptime_stats"]
 
     @property
     def user_num_sta(self) -> int:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1093,6 +1093,41 @@ GATEWAY_USG3 = {
         "xput_up": 0.0,
     },
     "uptime": 3971869,
+    "uptime_stats": {
+        "WAN": {
+            "monitors": [
+                {
+                    "availability": 100.0,
+                    "latency_average": 5,
+                    "target": "www.microsoft.com",
+                    "type": "icmp",
+                },
+                {
+                    "availability": 100.0,
+                    "latency_average": 7,
+                    "target": "google.com",
+                    "type": "icmp",
+                },
+                {
+                    "availability": 100.0,
+                    "latency_average": 5,
+                    "target": "1.1.1.1",
+                    "type": "icmp",
+                },
+            ]
+        },
+        "WAN2": {
+            "monitors": [
+                {
+                    "availability": 0.0,
+                    "target": "www.microsoft.com",
+                    "type": "icmp",
+                },
+                {"availability": 0.0, "target": "google.com", "type": "icmp"},
+                {"availability": 0.0, "target": "1.1.1.1", "type": "icmp"},
+            ]
+        },
+    },
     "user-num_sta": 20,
     "usg_caps": 786431,
     "version": "4.4.44.5213844",

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1170,3 +1170,23 @@ async def test_led_status_request_exception(
     )
     with pytest.raises(AttributeError):
         DeviceSetLedStatus.create(device, **data)
+
+
+@pytest.mark.parametrize(("device_payload"), [[GATEWAY_USG3]])
+@pytest.mark.usefixtures("_mock_endpoints")
+async def test_update_stats(unifi_controller: Controller) -> None:
+    """Test device class uptime stats."""
+    await unifi_controller.devices.update()
+    device = next(iter(unifi_controller.devices.values()))
+
+    assert device.uptime_stats is not None
+    assert len(device.uptime_stats["WAN"].get("monitors")) == 3
+    assert len(device.uptime_stats["WAN2"].get("monitors")) == 3
+
+    assert device.uptime_stats["WAN"].get("monitors")[0].get("availability") == 100.0
+    assert device.uptime_stats["WAN"].get("monitors")[0].get("latency_average") == 5
+    assert (
+        device.uptime_stats["WAN"].get("monitors")[0].get("target")
+        == "www.microsoft.com"
+    )
+    assert device.uptime_stats["WAN"].get("monitors")[0].get("type") == "icmp"

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -121,6 +121,41 @@ test_data = [
             "uplink": GATEWAY_USG3["uplink"],
             "uplink_depth": None,
             "uptime": 3971869,
+            "uptime_stats": {
+                "WAN": {
+                    "monitors": [
+                        {
+                            "availability": 100.0,
+                            "latency_average": 5,
+                            "target": "www.microsoft.com",
+                            "type": "icmp",
+                        },
+                        {
+                            "availability": 100.0,
+                            "latency_average": 7,
+                            "target": "google.com",
+                            "type": "icmp",
+                        },
+                        {
+                            "availability": 100.0,
+                            "latency_average": 5,
+                            "target": "1.1.1.1",
+                            "type": "icmp",
+                        },
+                    ]
+                },
+                "WAN2": {
+                    "monitors": [
+                        {
+                            "availability": 0.0,
+                            "target": "www.microsoft.com",
+                            "type": "icmp",
+                        },
+                        {"availability": 0.0, "target": "google.com", "type": "icmp"},
+                        {"availability": 0.0, "target": "1.1.1.1", "type": "icmp"},
+                    ]
+                },
+            },
             "user_num_sta": 20,
             "wlan_overrides": [],
             "speedtest_status": GATEWAY_USG3["speedtest-status"],


### PR DESCRIPTION
It will be part of https://github.com/home-assistant/core/pull/116737

This will add typed info for update_stats.WAN.monitors


JSON example from a UDM SE

```json
{
  "data": [
    {
      "uptime_stats": {
        "WAN": {
          "monitors": [
            {
              "availability": 100.0,
              "latency_average": 5,
              "target": "www.microsoft.com",
              "type": "icmp"
            },
            {
              "availability": 100.0,
              "latency_average": 7,
              "target": "google.com",
              "type": "icmp"
            },
            {
              "availability": 100.0,
              "latency_average": 5,
              "target": "1.1.1.1",
              "type": "icmp"
            }
          ]
        },
        "WAN2": {
          "monitors": [
            {
              "availability": 0.0,
              "target": "www.microsoft.com",
              "type": "icmp"
            },
            {
              "availability": 0.0,
              "target": "google.com",
              "type": "icmp"
            },
            {
              "availability": 0.0,
              "target": "1.1.1.1",
              "type": "icmp"
            }
          ]
        }
      }
    }
  ]
}
```