### PR TITLE
Add voucher events

### DIFF
--- a/aiounifi/models/event.py
+++ b/aiounifi/models/event.py
@@ -68,6 +68,9 @@ class EventKey(enum.Enum):
     SWITCH_UPGRADE_SCHEDULED = "EVT_SW_UpgradeScheduled"
     SWITCH_UPGRADED = "EVT_SW_Upgraded"
 
+    VOUCHER_CREATED = "EVT_AD_VoucherCreated"
+    VOUCHER_DELETED = "EVT_AD_VoucherDeleted"
+
     WIRED_CLIENT_CONNECTED = "EVT_LU_Connected"
     WIRED_CLIENT_DISCONNECTED = "EVT_LU_Disconnected"
     WIRED_CLIENT_BLOCKED = "EVT_LC_Blocked"


### PR DESCRIPTION
In my production system I get the following warnings in the log when I use my voucher integration:
```log
2024-05-05 21:14:26.557 WARNING (MainThread) [aiounifi.models.event] Unsupported event key EVT_AD_VoucherCreated
2024-05-05 21:14:26.557 WARNING (MainThread) [aiounifi.models.event] Unsupported event {'num': '1', 'use': 'single-use', 'admin': 'Admin[Admin  ]', 'site_id': '5a32aa4ee4b0412345678910', 'is_admin': True, 'key': 'EVT_AD_VoucherCreated', 'subsystem': 'wlan', 'is_negative': False, 'time': 1714936463552, 'datetime': '2024-05-05T19:14:23Z', 'msg': 'Admin[Admin  ] created 1 single-use voucher(s)', '_id': '6637da8ff30c710b60b18251'}
2024-05-05 21:16:11.559 WARNING (MainThread) [aiounifi.models.event] Unsupported event key EVT_AD_VoucherDeleted
2024-05-05 21:16:11.560 WARNING (MainThread) [aiounifi.models.event] Unsupported event {'code': '9668964319', 'admin': 'Admin[Admin  ]', 'site_id': '5a32aa4ee4b0412345678910', 'is_admin': True, 'key': 'EVT_AD_VoucherDeleted', 'subsystem': 'wlan', 'is_negative': False, 'time': 1714936570825, 'datetime': '2024-05-05T19:16:10Z', 'msg': 'Voucher[9668964319] was deleted', '_id': '6637dafaf30c710b60b182b6'}
```

I can't reproduce it on a dev system, so I can't really debug it.

But I hope that the warnings will disappear as a result of the changes made. What do you say, @Kane610 ?