### PR TITLE
Add new event EVT_HS_AuthedByNoAuth

### DIFF
--- a/aiounifi/models/event.py
+++ b/aiounifi/models/event.py
@@ -102,6 +102,7 @@ class EventKey(enum.Enum):
     AD_LOGIN = "EVT_AD_Login"
     AD_SCHEDULE_UPGRADE_FAILED_NOT_FOUND = "EVT_AD_ScheduleUpgradeFailedNotFound"
 
+    HOT_SPOT_AUTHED_BY_NO_AUTH = "EVT_HS_AuthedByNoAuth"
     HOT_SPOT_AUTHED_BY_PASSWORD = "EVT_HS_AuthedByPassword"
     HOT_SPOT_VOUCHER_USED = "EVT_HS_VoucherUsed"
 


### PR DESCRIPTION
https://github.com/home-assistant/core/issues/134918

```
Logger: aiounifi.models.event
Source: components/unifi/hub/websocket.py:80
First occurred: 4:55:57 PM (62 occurrences)
Last logged: 4:55:57 PM

Unsupported event key EVT_HS_AuthedByNoAuth
Unsupported event {'guest': '52:66:5a:xx:xx:xx', 'key': 'EVT_HS_AuthedByNoAuth', 'subsystem': 'wlan', 'is_negative': False, 'site_id': 'yyyyyyyyyyyyyyyyyy', 'time': 1736175354603, 'datetime': '2025-01-06T14:55:54Z', 'msg': 'Guest[52:66:5a:xx:xx:xx] is authorized by no authentication', '_id': 'zzzzzzzzzzzzz'}
```