### PR TITLE
Add support for optional 'for_hotspot' and 'site_name' parameters in …

### DIFF
--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -71,6 +71,13 @@ class Connectivity:
             "rememberMe": True,
         }
 
+        # Voeg optionele parameters toe als deze door de gebruiker zijn opgegeven
+        if hasattr(self.config, "for_hotspot") and self.config.for_hotspot is not None:
+            auth["for_hotspot"] = self.config.for_hotspot
+
+        if hasattr(self.config, "site_name") and self.config.site_name is not None:
+            auth["site_name"] = self.config.site_name
+        
         response, bytes_data = await self._request("post", url, json=auth)
 
         if response.content_type != "application/json":


### PR DESCRIPTION
…login process

This update introduces the ability to include the 'for_hotspot' and 'site_name' fields in the login request if they are provided in the configuration. These parameters are dynamically added to the authentication payload to ensure compatibility with additional use cases without affecting the existing functionality.

- Check for 'for_hotspot' and 'site_name' attributes in the config.
- Include these fields in the login payload only if they are not None.
- Preserve the original login logic for backward compatibility.

Based on the following observed working example for logging in as a hotspot operator:
curl 'https://...:8443/api/login' --data-raw '{"username":"************","password":"**************","for_hotspot":true,"remember":false,"site_name":"default"}' --insecure

Adding the parameters `"for_hotspot": true` and `"site_name": "default"` resolves login issues for hotspot operator users.

Acknowledgment: Initial guidance for implementing this feature was provided with the assistance of ChatGPT.

Also, see: https://github.com/ufozone/ha-unifi-voucher/issues/125