### PR TITLE
Add support for optional 'for_hotspot' parameters in login process

### DIFF
--- a/aiounifi/__main__.py
+++ b/aiounifi/__main__.py
@@ -23,6 +23,7 @@ async def unifi_controller(
     site: str,
     session: aiohttp.ClientSession,
     ssl_context: SSLContext | None = None,
+    for_hotspot: bool | None = None, # New argument
 ) -> Controller | None:
     """Set up UniFi controller and verify credentials."""
     controller = Controller(
@@ -33,6 +34,7 @@ async def unifi_controller(
             password=password,
             port=port,
             site=site,
+            for_hotspot=for_hotspot, # New argument
             ssl_context=ssl_context if ssl_context is not None else False,
         )
     )

--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -72,10 +72,10 @@ class Connectivity:
         }
 
         if hasattr(self.config, "site") and self.config.site is not None:
-            auth["siteName"] = self.config.site
+            auth["site_name"] = self.config.site
 
         if hasattr(self.config, "for_hotspot") and self.config.for_hotspot is not None:
-            auth["forHotspot"] = self.config.for_hotspot
+            auth["for_hotspot"] = self.config.for_hotspot
         
         response, bytes_data = await self._request("post", url, json=auth)
 

--- a/aiounifi/interfaces/connectivity.py
+++ b/aiounifi/interfaces/connectivity.py
@@ -71,6 +71,12 @@ class Connectivity:
             "rememberMe": True,
         }
 
+        if hasattr(self.config, "site") and self.config.site is not None:
+            auth["siteName"] = self.config.site
+
+        if hasattr(self.config, "for_hotspot") and self.config.for_hotspot is not None:
+            auth["forHotspot"] = self.config.for_hotspot
+        
         response, bytes_data = await self._request("post", url, json=auth)
 
         if response.content_type != "application/json":

--- a/aiounifi/models/configuration.py
+++ b/aiounifi/models/configuration.py
@@ -18,6 +18,7 @@ class Configuration:
     password: str
     port: int = 8443
     site: str = "default"
+    for_hotspot: bool | None = None
     ssl_context: SSLContext | Literal[False] = False
 
     @property


### PR DESCRIPTION
To enable hotspot operator user to login.

This update introduces the ability to include the 'for_hotspot' and 'site_name' fields in the login request if they are provided in the configuration. 

Based on the following observed working example for logging in as a hotspot operator:
curl 'https://...:8443/api/login' --data-raw '{"username":"*******","password":"******","for_hotspot":true,"remember":false,"site_name":"default"}' --insecure

Adding the parameters "for_hotspot": true and "site_name": "default" resolves login issues for hotspot operator users.

See this for more information: https://github.com/ufozone/ha-unifi-voucher/issues/125#issuecomment-2601026022
Changes are verified to be working: https://github.com/ufozone/ha-unifi-voucher/issues/125#issuecomment-2602119647