### PR TITLE
fix port enabled/disabled

### DIFF
--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -807,14 +807,14 @@ class DeviceSetPortEnabledRequest(ApiRequest):
             existing_override = False
             for port_override in port_overrides:
                 if port_idx == port_override.get("port_idx"):
-                    port_override["enable"] = enabled
+                    port_override["port_security_enabled"] = not enabled
                     existing_override = True
                     break
 
             if existing_override:
                 continue
 
-            port_override = {"port_idx": port_idx, "enable": enabled}
+            port_override = {"port_idx": port_idx, "port_security_enabled": not enabled}
             if portconf_id := device.port_table[port_idx - 1].get("portconf_id"):
                 port_override["portconf_id"] = portconf_id
             port_overrides.append(port_override)

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -999,7 +999,7 @@ async def test_device_requests(
             ],
             DeviceSetPortEnabledRequest,
             {"port_idx": 1, "enabled": False},
-            {"port_overrides": [{"port_idx": 1, "enable": False}]},
+            {"port_overrides": [{"port_idx": 1, "port_security_enabled": True}]},
         ),
         (  # Port enable with portconf_id without existing override
             [
@@ -1021,7 +1021,7 @@ async def test_device_requests(
             {"port_idx": 1, "enabled": False},
             {
                 "port_overrides": [
-                    {"port_idx": 1, "enable": False, "portconf_id": "123"}
+                    {"port_idx": 1, "port_security_enabled": True, "portconf_id": "123"}
                 ]
             },
         ),
@@ -1042,7 +1042,7 @@ async def test_device_requests(
             ],
             DeviceSetPortEnabledRequest,
             {"port_idx": 1, "enabled": False},
-            {"port_overrides": [{"port_idx": 1, "name": "Office", "enable": False}]},
+            {"port_overrides": [{"port_idx": 1, "name": "Office", "port_security_enabled": True}]},
         ),
         (  # Port enable multiple ports
             [
@@ -1068,8 +1068,8 @@ async def test_device_requests(
             {"targets": [(1, False), (2, True)]},
             {
                 "port_overrides": [
-                    {"port_idx": 1, "enable": False, "name": "Office"},
-                    {"port_idx": 2, "enable": True},
+                    {"port_idx": 1, "port_security_enabled": True, "name": "Office"},
+                    {"port_idx": 2, "port_security_enabled": False},
                 ]
             },
         ),


### PR DESCRIPTION
# Fix DeviceSetPortEnabledRequest boolean logic and property name

## Problem
The `DeviceSetPortEnabledRequest` class had a bug where:

1. It was using the wrong property name (`enable` instead of `port_security_enabled`)
2. The boolean logic was incorrect since `port_security_enabled` has inverted semantics

## Root Cause
In the UniFi API:

- `port_security_enabled: true` means the port is **disabled** (security feature enabled)
- `port_security_enabled: false` means the port is **enabled** (security feature disabled)

However, the `DeviceSetPortEnabledRequest.create()` method was:

- Using the wrong property name (`enable`)
- Not inverting the boolean value to match the API semantics

## Solution
Updated `DeviceSetPortEnabledRequest` to:

1. Use the correct property name: `port_security_enabled`
2. Invert the boolean logic: `port_security_enabled: not enabled`

This ensures that:

- When `enabled=True` is passed → `port_security_enabled=False` (port enabled)
- When `enabled=False` is passed → `port_security_enabled=True` (port disabled)

## Changes Made
- **`aiounifi/models/device.py`**: Fixed property name and boolean logic in `DeviceSetPortEnabledRequest.create()`
- **`tests/test_devices.py`**: Updated test cases to expect `port_security_enabled` with inverted boolean values

## Testing
All existing tests updated to reflect the correct API behavior and property names.