### PR TITLE
Update DeviceSetPortEnabledRequest to match the GUI behavior.

### DIFF
--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -889,6 +889,7 @@ class Device(ApiItem):
 
     @property
     def connection_network_id(self) -> str:
+        """Native VLAN network ID."""
         return self.raw["connection_network_id"]
 
     @property

--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -892,7 +892,7 @@ class Device(ApiItem):
     @property
     def connection_network_id(self) -> str:
         """Native VLAN network ID."""
-        return self.raw["connection_network_id"]
+        return self.raw.get("connection_network_id", "")
 
     @property
     def considered_lost_at(self) -> int:

--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -138,6 +138,8 @@ class TypedDevicePortOverrides(TypedDict, total=False):
     port_idx: int
     port_security_enabled: bool
     portconf_id: str
+    tagged_vlan_mgmt: str
+    native_networkconf_id: str
 
 
 class TypedDevicePortTableLldpTable(TypedDict):

--- a/aiounifi/models/device.py
+++ b/aiounifi/models/device.py
@@ -412,6 +412,7 @@ class TypedDevice(TypedDict):
     config_network: TypedDeviceConfigNetwork
     connect_request_ip: str
     connect_request_port: str
+    connection_network_id: str
     considered_lost_at: int
     country_code: int
     countrycode_table: list  # type: ignore[type-arg]
@@ -807,14 +808,25 @@ class DeviceSetPortEnabledRequest(ApiRequest):
             existing_override = False
             for port_override in port_overrides:
                 if port_idx == port_override.get("port_idx"):
-                    port_override["port_security_enabled"] = not enabled
+                    port_override.update(
+                        {
+                            "port_security_enabled": not enabled,
+                            "tagged_vlan_mgmt": "auto" if enabled else "block_all",
+                            "native_networkconf_id": device.connection_network_id,
+                        }
+                    )
                     existing_override = True
                     break
 
             if existing_override:
                 continue
 
-            port_override = {"port_idx": port_idx, "port_security_enabled": not enabled}
+            port_override = {
+                "port_idx": port_idx,
+                "port_security_enabled": not enabled,
+                "tagged_vlan_mgmt": "auto" if enabled else "block_all",
+                "native_networkconf_id": device.connection_network_id,
+            }
             if portconf_id := device.port_table[port_idx - 1].get("portconf_id"):
                 port_override["portconf_id"] = portconf_id
             port_overrides.append(port_override)
@@ -874,6 +886,10 @@ class Device(ApiItem):
     def board_revision(self) -> int:
         """Board revision of device."""
         return self.raw.get("board_rev", 0)
+
+    @property
+    def connection_network_id(self) -> str:
+        return self.raw["connection_network_id"]
 
     @property
     def considered_lost_at(self) -> int:

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -784,9 +784,9 @@ async def test_device_requests(
     mock_aioresponse: aioresponses,
     unifi_controller: Controller,
     unifi_called_with: Callable[[str, str, dict[str, Any]], bool],
-    api_request: DeviceRestartRequest
-    | DeviceUpgradeRequest
-    | DevicePowerCyclePortRequest,
+    api_request: (
+        DeviceRestartRequest | DeviceUpgradeRequest | DevicePowerCyclePortRequest
+    ),
     data: dict[str, Any],
     command: dict[str, Any],
 ) -> None:
@@ -999,7 +999,16 @@ async def test_device_requests(
             ],
             DeviceSetPortEnabledRequest,
             {"port_idx": 1, "enabled": False},
-            {"port_overrides": [{"port_idx": 1, "port_security_enabled": True}]},
+            {
+                "port_overrides": [
+                    {
+                        "port_idx": 1,
+                        "port_security_enabled": True,
+                        "tagged_vlan_mgmt": "block_all",
+                        "native_networkconf_id": "",
+                    }
+                ]
+            },
         ),
         (  # Port enable with portconf_id without existing override
             [
@@ -1021,7 +1030,13 @@ async def test_device_requests(
             {"port_idx": 1, "enabled": False},
             {
                 "port_overrides": [
-                    {"port_idx": 1, "port_security_enabled": True, "portconf_id": "123"}
+                    {
+                        "port_idx": 1,
+                        "port_security_enabled": True,
+                        "portconf_id": "123",
+                        "tagged_vlan_mgmt": "block_all",
+                        "native_networkconf_id": "",
+                    }
                 ]
             },
         ),
@@ -1044,7 +1059,13 @@ async def test_device_requests(
             {"port_idx": 1, "enabled": False},
             {
                 "port_overrides": [
-                    {"port_idx": 1, "name": "Office", "port_security_enabled": True}
+                    {
+                        "port_idx": 1,
+                        "name": "Office",
+                        "port_security_enabled": True,
+                        "tagged_vlan_mgmt": "block_all",
+                        "native_networkconf_id": "",
+                    }
                 ]
             },
         ),
@@ -1072,8 +1093,19 @@ async def test_device_requests(
             {"targets": [(1, False), (2, True)]},
             {
                 "port_overrides": [
-                    {"port_idx": 1, "port_security_enabled": True, "name": "Office"},
-                    {"port_idx": 2, "port_security_enabled": False},
+                    {
+                        "port_idx": 1,
+                        "port_security_enabled": True,
+                        "name": "Office",
+                        "tagged_vlan_mgmt": "block_all",
+                        "native_networkconf_id": "",
+                    },
+                    {
+                        "port_idx": 2,
+                        "port_security_enabled": False,
+                        "tagged_vlan_mgmt": "auto",
+                        "native_networkconf_id": "1337",
+                    },
                 ]
             },
         ),
@@ -1084,10 +1116,12 @@ async def test_sub_device_requests(
     mock_aioresponse: aioresponses,
     unifi_controller: Controller,
     unifi_called_with: Callable[[str, str, dict[str, Any]], bool],
-    api_request: DeviceSetOutletRelayRequest
-    | DeviceSetOutletCycleEnabledRequest
-    | DeviceSetPoePortModeRequest
-    | DeviceSetPortEnabledRequest,
+    api_request: (
+        DeviceSetOutletRelayRequest
+        | DeviceSetOutletCycleEnabledRequest
+        | DeviceSetPoePortModeRequest
+        | DeviceSetPortEnabledRequest
+    ),
     data: dict[str, Any],
     command: dict[str, Any],
 ) -> None:

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1104,7 +1104,7 @@ async def test_device_requests(
                         "port_idx": 2,
                         "port_security_enabled": False,
                         "tagged_vlan_mgmt": "auto",
-                        "native_networkconf_id": "1337",
+                        "native_networkconf_id": "",
                     },
                 ]
             },


### PR DESCRIPTION
As of current, when `port_security_enabled` is set to `True` - the unifi controller will switch (and broadcast to the websocket) that both VLAN settings are disabled (`'native_networkconf_id': '', 'tagged_vlan_mgmt': 'block_all'`). This matches the behavior of the GUI.

On the invert of that (when the user needs to **enable** the port), since **only** the `port_security_enabled` property is modified - both VLANS settings will remain to the previous *disabled* mode. This deviates from the GUI, where there the VLAN id will be set to the configured default and tagged traffic will be set to auto.

A unique side effect of this also appears in the hass integration. When both these settings remain to the *disabled state*, the port on the `port_table` event will have it's `enabled` attribute to `false`. This creates a very weird state (not even allowed by the GUI) where the port is technically **enabled**, but since all VLAN traffic is **disabled**, hass thinks the whole port is disabled. https://github.com/home-assistant/core/blob/87f0703be17a20f0f87a1d7d76ca0781173555ab/homeassistant/components/unifi/switch.py#L371

Current code causes the port to be set to active (red box) while the VLANs stay disabled (green box). <img width="384" height="208" alt="image" src="https://github.com/user-attachments/assets/4fa8f517-6a2f-4f80-8651-0547f9d94e2f" />

While this patch works (on my hass/switch), I think the ideal scenario would be to store the port configuration (somewhere/how/where?) *before it's disabled* and **revert** this when it's re-enabled. This idea, doesn't really concern this library directly, but could be a nice feature to have. (I could help there, but not really familiar on what's possible on hass)
