### PR TITLE
Add speedtest interface

### DIFF
--- a/aiounifi/controller.py
+++ b/aiounifi/controller.py
@@ -19,6 +19,7 @@ from .interfaces.outlets import Outlets
 from .interfaces.port_forwarding import PortForwarding
 from .interfaces.ports import Ports
 from .interfaces.sites import Sites
+from .interfaces.speedtest import SpeedtestHandler
 from .interfaces.system_information import SystemInformationHandler
 from .interfaces.traffic_routes import TrafficRoutes
 from .interfaces.traffic_rules import TrafficRules
@@ -53,6 +54,7 @@ class Controller:
         self.port_forwarding = PortForwarding(self)
         self.ports = Ports(self)
         self.sites = Sites(self)
+        self.speedtest = SpeedtestHandler(self)
         self.system_information = SystemInformationHandler(self)
         self.traffic_rules = TrafficRules(self)
         self.traffic_routes = TrafficRoutes(self)

--- a/aiounifi/interfaces/speedtest.py
+++ b/aiounifi/interfaces/speedtest.py
@@ -1,0 +1,55 @@
+"""Speedtest interface."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ..models.speedtest import (
+    SpeedtestStatus,
+    SpeedtestStatusLegacyRequest,
+    SpeedtestStatusRequest,
+    SpeedtestTriggerLegacyRequest,
+    SpeedtestTriggerRequest,
+)
+
+if TYPE_CHECKING:
+    from ..controller import Controller
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SpeedtestHandler:
+    """Represents the speedtest interface."""
+
+    def __init__(self, controller: Controller) -> None:
+        """Initialize speedtest handler."""
+        self.controller = controller
+
+    async def fetch(self) -> SpeedtestStatus | None:
+        """Fetch the latest speedtest status."""
+        if self.controller.connectivity.is_unifi_os:
+            # Hardware controllers use the V2 endpoint
+            # It returns a list of tests in 'data'
+            res = await self.controller.request(SpeedtestStatusRequest.create())
+            raw_data = res.get("data", [])
+            if raw_data:
+                # Return the most recent test (sort by time instead of assuming last is newest)
+                latest = sorted(raw_data, key=lambda x: x.get("time", 0))[-1]
+                return SpeedtestStatus(latest)
+            return None
+
+        # Software controllers use the legacy health endpoint
+        res = await self.controller.request(SpeedtestStatusLegacyRequest.create())
+        raw_data = res.get("data", [])
+        for subsystem in raw_data:
+            if subsystem.get("subsystem") == "www":
+                return SpeedtestStatus(subsystem)
+        return None
+
+    async def trigger(self) -> None:
+        """Trigger a speedtest."""
+        if self.controller.connectivity.is_unifi_os:
+            await self.controller.request(SpeedtestTriggerRequest.create())
+        else:
+            await self.controller.request(SpeedtestTriggerLegacyRequest.create())

--- a/aiounifi/interfaces/speedtest.py
+++ b/aiounifi/interfaces/speedtest.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from ..models.speedtest import (
+from aiounifi.models.speedtest import (
     SpeedtestStatus,
     SpeedtestStatusLegacyRequest,
     SpeedtestStatusRequest,
@@ -14,7 +14,7 @@ from ..models.speedtest import (
 )
 
 if TYPE_CHECKING:
-    from ..controller import Controller
+    from aiounifi.controller import Controller
 
 LOGGER = logging.getLogger(__name__)
 
@@ -30,9 +30,14 @@ class SpeedtestHandler:
         """Fetch the latest speedtest status."""
         if self.controller.connectivity.is_unifi_os:
             # Hardware controllers use the V2 endpoint
-            # It returns a list of tests in 'data'
+            # It returns a list of tests in 'data', sometimes nested in an outer 'data' list
             res = await self.controller.request(SpeedtestStatusRequest.create())
             raw_data = res.get("data", [])
+
+            # Handle nested 'data' structure
+            if raw_data and isinstance(raw_data[0], dict) and "data" in raw_data[0]:
+                raw_data = raw_data[0].get("data", [])
+
             if raw_data:
                 # Return the most recent test (sort by time instead of assuming last is newest)
                 latest = sorted(raw_data, key=lambda x: x.get("time", 0))[-1]

--- a/aiounifi/interfaces/speedtest.py
+++ b/aiounifi/interfaces/speedtest.py
@@ -3,58 +3,25 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
 
 from aiounifi.models.speedtest import (
     SpeedtestStatus,
-    SpeedtestStatusLegacyRequest,
     SpeedtestStatusRequest,
-    SpeedtestTriggerLegacyRequest,
     SpeedtestTriggerRequest,
 )
 
-if TYPE_CHECKING:
-    from aiounifi.controller import Controller
+from .api_handlers import APIHandler
 
 LOGGER = logging.getLogger(__name__)
 
 
-class SpeedtestHandler:
+class SpeedtestHandler(APIHandler[SpeedtestStatus]):
     """Represents the speedtest interface."""
 
-    def __init__(self, controller: Controller) -> None:
-        """Initialize speedtest handler."""
-        self.controller = controller
-
-    async def fetch(self) -> SpeedtestStatus | None:
-        """Fetch the latest speedtest status."""
-        if self.controller.connectivity.is_unifi_os:
-            # Hardware controllers use the V2 endpoint
-            # It returns a list of tests in 'data', sometimes nested in an outer 'data' list
-            res = await self.controller.request(SpeedtestStatusRequest.create())
-            raw_data = res.get("data", [])
-
-            # Handle nested 'data' structure
-            if raw_data and isinstance(raw_data[0], dict) and "data" in raw_data[0]:
-                raw_data = raw_data[0].get("data", [])
-
-            if raw_data:
-                # Return the most recent test (sort by time instead of assuming last is newest)
-                latest = sorted(raw_data, key=lambda x: x.get("time", 0))[-1]
-                return SpeedtestStatus(latest)
-            return None
-
-        # Software controllers use the legacy health endpoint
-        res = await self.controller.request(SpeedtestStatusLegacyRequest.create())
-        raw_data = res.get("data", [])
-        for subsystem in raw_data:
-            if subsystem.get("subsystem") == "www":
-                return SpeedtestStatus(subsystem)
-        return None
+    obj_id_key = "id"
+    item_cls = SpeedtestStatus
+    api_request = SpeedtestStatusRequest.create()
 
     async def trigger(self) -> None:
         """Trigger a speedtest."""
-        if self.controller.connectivity.is_unifi_os:
-            await self.controller.request(SpeedtestTriggerRequest.create())
-        else:
-            await self.controller.request(SpeedtestTriggerLegacyRequest.create())
+        await self.controller.request(SpeedtestTriggerRequest.create())

--- a/aiounifi/interfaces/speedtest.py
+++ b/aiounifi/interfaces/speedtest.py
@@ -18,7 +18,7 @@ LOGGER = logging.getLogger(__name__)
 class SpeedtestHandler(APIHandler[SpeedtestStatus]):
     """Represents the speedtest interface."""
 
-    obj_id_key = "id"
+    obj_id_key = "interface_name"
     item_cls = SpeedtestStatus
     api_request = SpeedtestStatusRequest.create()
 

--- a/aiounifi/models/speedtest.py
+++ b/aiounifi/models/speedtest.py
@@ -3,23 +3,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TypedDict
+from typing import Any, NotRequired, TypedDict
 
 from .api import ApiItem, ApiRequest, ApiRequestV2, TypedApiResponse
 
 
-class TypedSpeedtestStatus(TypedDict, total=False):
+class TypedSpeedtestStatus(TypedDict):
     """Speedtest status type definition."""
 
-    status: str
-    status_text: str
     download_mbps: float
     upload_mbps: float
     latency_ms: float
     time: int
-    id: str
-    interface_name: str
-    wan_networkgroup: str
+    id: NotRequired[str]
+    interface_name: NotRequired[str]
+    wan_networkgroup: NotRequired[str]
 
 
 @dataclass
@@ -35,8 +33,18 @@ class SpeedtestStatusRequest(ApiRequestV2):
         """Decode response and extract nested data if present."""
         data = super().decode(raw)
 
-        if "data" in data and data["data"] and "data" in data["data"][0]:
-            data["data"] = data["data"][0]["data"]
+        if data.get("data"):
+            latest_by_interface: dict[str, dict[str, Any]] = {}
+            for result in data["data"]:
+                interface = result.get("interface_name", "default")
+                result["interface_name"] = interface
+
+                if interface not in latest_by_interface or result.get(
+                    "time", 0
+                ) >= latest_by_interface[interface].get("time", 0):
+                    latest_by_interface[interface] = result
+
+            data["data"] = list(latest_by_interface.values())
 
         return data
 
@@ -55,17 +63,6 @@ class SpeedtestStatus(ApiItem):
     """Represents a speedtest status."""
 
     raw: TypedSpeedtestStatus
-
-    @property
-    def status(self) -> str:
-        """Status of the speedtest."""
-        val = self.raw.get("status_text", self.raw.get("status"))
-        if val is not None:
-            return str(val)
-        # V2 endpoints don't seem to return a status explicitly for completed historical runs
-        if "download_mbps" in self.raw:
-            return "Completed"
-        return "unknown"
 
     @property
     def download(self) -> float:

--- a/aiounifi/models/speedtest.py
+++ b/aiounifi/models/speedtest.py
@@ -78,7 +78,15 @@ class SpeedtestStatus(ApiItem):
     @property
     def status(self) -> str:
         """Status of the speedtest."""
-        return str(self.raw.get("status_text", self.raw.get("status", self.raw.get("speedtest_status", "unknown"))))
+        val = self.raw.get(
+            "status_text", self.raw.get("status", self.raw.get("speedtest_status"))
+        )
+        if val is not None:
+            return str(val)
+        # V2 endpoints don't seem to return a status explicitly for completed historical runs
+        if "download_mbps" in self.raw or "xput_down" in self.raw:
+            return "Completed"
+        return "unknown"
 
     @property
     def download(self) -> float:
@@ -99,4 +107,3 @@ class SpeedtestStatus(ApiItem):
     def timestamp(self) -> int:
         """Timestamp of the test."""
         return int(self.raw.get("time", self.raw.get("speedtest_lastrun", 0)))
-

--- a/aiounifi/models/speedtest.py
+++ b/aiounifi/models/speedtest.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TypedDict
 
-from .api import ApiItem, ApiRequest, ApiRequestV2
+from .api import ApiItem, ApiRequest, ApiRequestV2, TypedApiResponse
 
 
 class TypedSpeedtestStatus(TypedDict, total=False):
     """Speedtest status type definition."""
 
-    # V2 Endpoint keys
     status: str
     status_text: str
     download_mbps: float
@@ -21,13 +20,6 @@ class TypedSpeedtestStatus(TypedDict, total=False):
     id: str
     interface_name: str
     wan_networkgroup: str
-
-    # Legacy Health Endpoint keys
-    xput_down: float
-    xput_up: float
-    speedtest_ping: float
-    speedtest_lastrun: int
-    speedtest_status: str
 
 
 @dataclass
@@ -39,15 +31,14 @@ class SpeedtestStatusRequest(ApiRequestV2):
         """Create hardware speedtest status request."""
         return cls(method="get", path="/speedtest")
 
+    def decode(self, raw: bytes) -> TypedApiResponse:
+        """Decode response and extract nested data if present."""
+        data = super().decode(raw)
 
-@dataclass
-class SpeedtestStatusLegacyRequest(ApiRequest):
-    """Request object for software controller speedtest status (health)."""
+        if "data" in data and data["data"] and "data" in data["data"][0]:
+            data["data"] = data["data"][0]["data"]
 
-    @classmethod
-    def create(cls) -> SpeedtestStatusLegacyRequest:
-        """Create software speedtest status request."""
-        return cls(method="get", path="/stat/health")
+        return data
 
 
 @dataclass
@@ -60,16 +51,6 @@ class SpeedtestTriggerRequest(ApiRequest):
         return cls(method="post", path="/cmd/devmgr/speedtest", data={})
 
 
-@dataclass
-class SpeedtestTriggerLegacyRequest(ApiRequest):
-    """Request object for triggering a legacy/software speedtest."""
-
-    @classmethod
-    def create(cls) -> SpeedtestTriggerLegacyRequest:
-        """Create legacy speedtest trigger request."""
-        return cls(method="post", path="/cmd/devmgr", data={"cmd": "speedtest"})
-
-
 class SpeedtestStatus(ApiItem):
     """Represents a speedtest status."""
 
@@ -78,32 +59,30 @@ class SpeedtestStatus(ApiItem):
     @property
     def status(self) -> str:
         """Status of the speedtest."""
-        val = self.raw.get(
-            "status_text", self.raw.get("status", self.raw.get("speedtest_status"))
-        )
+        val = self.raw.get("status_text", self.raw.get("status"))
         if val is not None:
             return str(val)
         # V2 endpoints don't seem to return a status explicitly for completed historical runs
-        if "download_mbps" in self.raw or "xput_down" in self.raw:
+        if "download_mbps" in self.raw:
             return "Completed"
         return "unknown"
 
     @property
     def download(self) -> float:
         """Download speed in Mbps."""
-        return float(self.raw.get("download_mbps", self.raw.get("xput_down", 0.0)))
+        return float(self.raw.get("download_mbps", 0.0))
 
     @property
     def upload(self) -> float:
         """Upload speed in Mbps."""
-        return float(self.raw.get("upload_mbps", self.raw.get("xput_up", 0.0)))
+        return float(self.raw.get("upload_mbps", 0.0))
 
     @property
     def ping(self) -> float:
         """Ping in ms."""
-        return float(self.raw.get("latency_ms", self.raw.get("speedtest_ping", 0.0)))
+        return float(self.raw.get("latency_ms", 0.0))
 
     @property
     def timestamp(self) -> int:
         """Timestamp of the test."""
-        return int(self.raw.get("time", self.raw.get("speedtest_lastrun", 0)))
+        return int(self.raw.get("time", 0))

--- a/aiounifi/models/speedtest.py
+++ b/aiounifi/models/speedtest.py
@@ -1,0 +1,102 @@
+"""UniFi speedtest models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypedDict
+
+from .api import ApiItem, ApiRequest, ApiRequestV2
+
+
+class TypedSpeedtestStatus(TypedDict, total=False):
+    """Speedtest status type definition."""
+
+    # V2 Endpoint keys
+    status: str
+    status_text: str
+    download_mbps: float
+    upload_mbps: float
+    latency_ms: float
+    time: int
+    id: str
+    interface_name: str
+    wan_networkgroup: str
+
+    # Legacy Health Endpoint keys
+    xput_down: float
+    xput_up: float
+    speedtest_ping: float
+    speedtest_lastrun: int
+    speedtest_status: str
+
+
+@dataclass
+class SpeedtestStatusRequest(ApiRequestV2):
+    """Request object for hardware speedtest status."""
+
+    @classmethod
+    def create(cls) -> SpeedtestStatusRequest:
+        """Create hardware speedtest status request."""
+        return cls(method="get", path="/speedtest")
+
+
+@dataclass
+class SpeedtestStatusLegacyRequest(ApiRequest):
+    """Request object for software controller speedtest status (health)."""
+
+    @classmethod
+    def create(cls) -> SpeedtestStatusLegacyRequest:
+        """Create software speedtest status request."""
+        return cls(method="get", path="/stat/health")
+
+
+@dataclass
+class SpeedtestTriggerRequest(ApiRequest):
+    """Request object for triggering a hardware speedtest."""
+
+    @classmethod
+    def create(cls) -> SpeedtestTriggerRequest:
+        """Create speedtest trigger request."""
+        return cls(method="post", path="/cmd/devmgr/speedtest", data={})
+
+
+@dataclass
+class SpeedtestTriggerLegacyRequest(ApiRequest):
+    """Request object for triggering a legacy/software speedtest."""
+
+    @classmethod
+    def create(cls) -> SpeedtestTriggerLegacyRequest:
+        """Create legacy speedtest trigger request."""
+        return cls(method="post", path="/cmd/devmgr", data={"cmd": "speedtest"})
+
+
+class SpeedtestStatus(ApiItem):
+    """Represents a speedtest status."""
+
+    raw: TypedSpeedtestStatus
+
+    @property
+    def status(self) -> str:
+        """Status of the speedtest."""
+        return str(self.raw.get("status_text", self.raw.get("status", self.raw.get("speedtest_status", "unknown"))))
+
+    @property
+    def download(self) -> float:
+        """Download speed in Mbps."""
+        return float(self.raw.get("download_mbps", self.raw.get("xput_down", 0.0)))
+
+    @property
+    def upload(self) -> float:
+        """Upload speed in Mbps."""
+        return float(self.raw.get("upload_mbps", self.raw.get("xput_up", 0.0)))
+
+    @property
+    def ping(self) -> float:
+        """Ping in ms."""
+        return float(self.raw.get("latency_ms", self.raw.get("speedtest_ping", 0.0)))
+
+    @property
+    def timestamp(self) -> int:
+        """Timestamp of the test."""
+        return int(self.raw.get("time", self.raw.get("speedtest_lastrun", 0)))
+

--- a/aiounifi/models/speedtest.py
+++ b/aiounifi/models/speedtest.py
@@ -34,6 +34,9 @@ class SpeedtestStatusRequest(ApiRequestV2):
         data = super().decode(raw)
 
         if data.get("data"):
+            if "data" in data["data"][0]:
+                data["data"] = data["data"][0]["data"]
+
             latest_by_interface: dict[str, dict[str, Any]] = {}
             for result in data["data"]:
                 interface = result.get("interface_name", "default")

--- a/tests/test_speedtest.py
+++ b/tests/test_speedtest.py
@@ -4,22 +4,17 @@ from collections.abc import Callable
 
 from aioresponses import aioresponses
 from aiounifi.controller import Controller
-from aiounifi.models.speedtest import (
-    SpeedtestStatusLegacyRequest,
-    SpeedtestStatusRequest,
-    SpeedtestTriggerLegacyRequest,
-    SpeedtestTriggerRequest,
-)
+from aiounifi.models.speedtest import SpeedtestStatusRequest, SpeedtestTriggerRequest
 import pytest
 
 
 @pytest.mark.asyncio
-async def test_speedtest_status_hardware_request(
+async def test_speedtest_status_request(
     mock_aioresponse: aioresponses,
     unifi_controller: Controller,
     unifi_called_with: Callable[..., bool],
 ) -> None:
-    """Test hardware speedtest status."""
+    """Test speedtest status."""
     mock_aioresponse.get(
         "https://host:8443/proxy/network/v2/api/site/default/speedtest", payload=[]
     )
@@ -29,25 +24,12 @@ async def test_speedtest_status_hardware_request(
 
 
 @pytest.mark.asyncio
-async def test_speedtest_status_software_request(
+async def test_speedtest_trigger_request(
     mock_aioresponse: aioresponses,
     unifi_controller: Controller,
     unifi_called_with: Callable[..., bool],
 ) -> None:
-    """Test software speedtest status."""
-    mock_aioresponse.get("https://host:8443/api/s/default/stat/health", payload={})
-    unifi_controller.connectivity.is_unifi_os = False
-    await unifi_controller.request(SpeedtestStatusLegacyRequest.create())
-    assert unifi_called_with("get", "/api/s/default/stat/health")
-
-
-@pytest.mark.asyncio
-async def test_speedtest_trigger_hardware_request(
-    mock_aioresponse: aioresponses,
-    unifi_controller: Controller,
-    unifi_called_with: Callable[..., bool],
-) -> None:
-    """Test hardware speedtest trigger."""
+    """Test speedtest trigger."""
     mock_aioresponse.post(
         "https://host:8443/proxy/network/api/s/default/cmd/devmgr/speedtest", payload={}
     )
@@ -57,29 +39,15 @@ async def test_speedtest_trigger_hardware_request(
 
 
 @pytest.mark.asyncio
-async def test_speedtest_trigger_software_request(
-    mock_aioresponse: aioresponses,
-    unifi_controller: Controller,
-    unifi_called_with: Callable[..., bool],
-) -> None:
-    """Test software speedtest trigger."""
-    mock_aioresponse.post("https://host:8443/api/s/default/cmd/devmgr", payload={})
-    unifi_controller.connectivity.is_unifi_os = False
-    await unifi_controller.request(SpeedtestTriggerLegacyRequest.create())
-    assert unifi_called_with(
-        "post", "/api/s/default/cmd/devmgr", json={"cmd": "speedtest"}
-    )
-
-
-@pytest.mark.asyncio
-async def test_speedtest_handler_fetch_hardware(
+async def test_speedtest_handler_update(
     mock_aioresponse: aioresponses, unifi_controller: Controller
 ) -> None:
-    """Test hardware speedtest fetch returns most recent."""
+    """Test speedtest update."""
     mock_aioresponse.get(
         "https://host:8443/proxy/network/v2/api/site/default/speedtest",
         payload=[
             {
+                "id": "1",
                 "time": 100,
                 "status": "completed",
                 "download_mbps": 500,
@@ -87,6 +55,7 @@ async def test_speedtest_handler_fetch_hardware(
                 "latency_ms": 10,
             },
             {
+                "id": "2",
                 "time": 150,
                 "status": "failed",
                 "download_mbps": 0,
@@ -96,8 +65,10 @@ async def test_speedtest_handler_fetch_hardware(
         ],
     )
     unifi_controller.connectivity.is_unifi_os = True
-    status = await unifi_controller.speedtest.fetch()
-    assert status is not None
+    await unifi_controller.speedtest.update()
+
+    assert len(unifi_controller.speedtest.values()) == 2
+    status = unifi_controller.speedtest["2"]
     assert status.timestamp == 150
     assert status.status == "failed"
     assert status.download == 0
@@ -106,14 +77,15 @@ async def test_speedtest_handler_fetch_hardware(
 
 
 @pytest.mark.asyncio
-async def test_speedtest_handler_fetch_hardware_implicit_status(
+async def test_speedtest_handler_update_implicit_status(
     mock_aioresponse: aioresponses, unifi_controller: Controller
 ) -> None:
-    """Test hardware speedtest fetch returns Completed when no explicit status is provided."""
+    """Test speedtest update returns Completed when no explicit status is provided."""
     mock_aioresponse.get(
         "https://host:8443/proxy/network/v2/api/site/default/speedtest",
         payload=[
             {
+                "id": "1",
                 "time": 200,
                 "download_mbps": 1000,
                 "upload_mbps": 500,
@@ -122,92 +94,50 @@ async def test_speedtest_handler_fetch_hardware_implicit_status(
         ],
     )
     unifi_controller.connectivity.is_unifi_os = True
-    status = await unifi_controller.speedtest.fetch()
-    assert status is not None
+    await unifi_controller.speedtest.update()
+
+    assert len(unifi_controller.speedtest.values()) == 1
+    status = unifi_controller.speedtest["1"]
     assert status.status == "Completed"
     assert status.download == 1000
 
 
 @pytest.mark.asyncio
-async def test_speedtest_handler_fetch_hardware_implicit_unknown(
+async def test_speedtest_handler_update_implicit_unknown(
     mock_aioresponse: aioresponses, unifi_controller: Controller
 ) -> None:
-    """Test hardware speedtest fetch returns unknown when no speeds exist either."""
+    """Test speedtest update returns unknown when no speeds exist either."""
     mock_aioresponse.get(
         "https://host:8443/proxy/network/v2/api/site/default/speedtest",
-        payload=[{"time": 200}],
+        payload=[{"id": "1", "time": 200}],
     )
     unifi_controller.connectivity.is_unifi_os = True
-    status = await unifi_controller.speedtest.fetch()
-    assert status is not None
+    await unifi_controller.speedtest.update()
+
+    status = unifi_controller.speedtest["1"]
     assert status.status == "unknown"
 
 
 @pytest.mark.asyncio
-async def test_speedtest_handler_fetch_hardware_empty(
+async def test_speedtest_handler_update_empty(
     mock_aioresponse: aioresponses, unifi_controller: Controller
 ) -> None:
-    """Test hardware speedtest fetch empty data."""
+    """Test speedtest update empty data."""
     mock_aioresponse.get(
         "https://host:8443/proxy/network/v2/api/site/default/speedtest", payload=[]
     )
     unifi_controller.connectivity.is_unifi_os = True
-    status = await unifi_controller.speedtest.fetch()
-    assert status is None
+    await unifi_controller.speedtest.update()
+    assert len(unifi_controller.speedtest.values()) == 0
 
 
 @pytest.mark.asyncio
-async def test_speedtest_handler_fetch_software(
-    mock_aioresponse: aioresponses, unifi_controller: Controller
-) -> None:
-    """Test software speedtest fetch returns www subsystem."""
-    mock_aioresponse.get(
-        "https://host:8443/api/s/default/stat/health",
-        payload={
-            "data": [
-                {"subsystem": "lan", "status": "ok"},
-                {
-                    "subsystem": "www",
-                    "speedtest_lastrun": 200,
-                    "speedtest_status": "completed",
-                    "xput_down": 400,
-                    "xput_up": 200,
-                    "speedtest_ping": 15,
-                },
-            ]
-        },
-    )
-    unifi_controller.connectivity.is_unifi_os = False
-    status = await unifi_controller.speedtest.fetch()
-    assert status is not None
-    assert status.timestamp == 200
-    assert status.status == "completed"
-    assert status.download == 400
-    assert status.upload == 200
-    assert status.ping == 15
-
-
-@pytest.mark.asyncio
-async def test_speedtest_handler_fetch_software_empty(
-    mock_aioresponse: aioresponses, unifi_controller: Controller
-) -> None:
-    """Test software speedtest fetch missing www subsystem."""
-    mock_aioresponse.get(
-        "https://host:8443/api/s/default/stat/health",
-        payload={"data": [{"subsystem": "lan", "status": "ok"}]},
-    )
-    unifi_controller.connectivity.is_unifi_os = False
-    status = await unifi_controller.speedtest.fetch()
-    assert status is None
-
-
-@pytest.mark.asyncio
-async def test_speedtest_handler_trigger_hardware(
+async def test_speedtest_handler_trigger(
     mock_aioresponse: aioresponses,
     unifi_controller: Controller,
     unifi_called_with: Callable[..., bool],
 ) -> None:
-    """Test hardware speedtest trigger function."""
+    """Test speedtest trigger function."""
     mock_aioresponse.post(
         "https://host:8443/proxy/network/api/s/default/cmd/devmgr/speedtest", payload={}
     )
@@ -217,15 +147,31 @@ async def test_speedtest_handler_trigger_hardware(
 
 
 @pytest.mark.asyncio
-async def test_speedtest_handler_trigger_software(
-    mock_aioresponse: aioresponses,
-    unifi_controller: Controller,
-    unifi_called_with: Callable[..., bool],
+async def test_speedtest_handler_update_nested(
+    mock_aioresponse: aioresponses, unifi_controller: Controller
 ) -> None:
-    """Test software speedtest trigger function."""
-    mock_aioresponse.post("https://host:8443/api/s/default/cmd/devmgr", payload={})
-    unifi_controller.connectivity.is_unifi_os = False
-    await unifi_controller.speedtest.trigger()
-    assert unifi_called_with(
-        "post", "/api/s/default/cmd/devmgr", json={"cmd": "speedtest"}
+    """Test speedtest update with nested data structure."""
+    mock_aioresponse.get(
+        "https://host:8443/proxy/network/v2/api/site/default/speedtest",
+        payload=[
+            {
+                "data": [
+                    {
+                        "id": "1",
+                        "time": 300,
+                        "status": "completed",
+                        "download_mbps": 800,
+                        "upload_mbps": 400,
+                        "latency_ms": 15,
+                    }
+                ]
+            }
+        ],
     )
+    unifi_controller.connectivity.is_unifi_os = True
+    await unifi_controller.speedtest.update()
+
+    assert len(unifi_controller.speedtest.values()) == 1
+    status = unifi_controller.speedtest["1"]
+    assert status.timestamp == 300
+    assert status.download == 800

--- a/tests/test_speedtest.py
+++ b/tests/test_speedtest.py
@@ -1,0 +1,161 @@
+"""Test speedtest API."""
+
+from collections.abc import Callable
+from typing import Any
+
+from aioresponses import aioresponses
+import pytest
+
+from aiounifi.controller import Controller
+from aiounifi.models.speedtest import (
+    SpeedtestStatusLegacyRequest,
+    SpeedtestStatusRequest,
+    SpeedtestTriggerLegacyRequest,
+    SpeedtestTriggerRequest,
+)
+
+
+@pytest.mark.asyncio
+async def test_speedtest_status_hardware_request(
+    mock_aioresponse: aioresponses,
+    unifi_controller: Controller,
+    unifi_called_with: Callable[..., bool],
+) -> None:
+    """Test hardware speedtest status."""
+    mock_aioresponse.get("https://host:8443/proxy/network/v2/api/site/default/speedtest", payload=[])
+    unifi_controller.connectivity.is_unifi_os = True
+    await unifi_controller.request(SpeedtestStatusRequest.create())
+    assert unifi_called_with("get", "/v2/api/site/default/speedtest")
+
+
+@pytest.mark.asyncio
+async def test_speedtest_status_software_request(
+    mock_aioresponse: aioresponses,
+    unifi_controller: Controller,
+    unifi_called_with: Callable[..., bool],
+) -> None:
+    """Test software speedtest status."""
+    mock_aioresponse.get("https://host:8443/api/s/default/stat/health", payload={})
+    unifi_controller.connectivity.is_unifi_os = False
+    await unifi_controller.request(SpeedtestStatusLegacyRequest.create())
+    assert unifi_called_with("get", "/api/s/default/stat/health")
+
+
+@pytest.mark.asyncio
+async def test_speedtest_trigger_hardware_request(
+    mock_aioresponse: aioresponses,
+    unifi_controller: Controller,
+    unifi_called_with: Callable[..., bool],
+) -> None:
+    """Test hardware speedtest trigger."""
+    mock_aioresponse.post("https://host:8443/proxy/network/api/s/default/cmd/devmgr/speedtest", payload={})
+    unifi_controller.connectivity.is_unifi_os = True
+    await unifi_controller.request(SpeedtestTriggerRequest.create())
+    assert unifi_called_with("post", "/api/s/default/cmd/devmgr/speedtest")
+
+
+@pytest.mark.asyncio
+async def test_speedtest_trigger_software_request(
+    mock_aioresponse: aioresponses,
+    unifi_controller: Controller,
+    unifi_called_with: Callable[..., bool],
+) -> None:
+    """Test software speedtest trigger."""
+    mock_aioresponse.post("https://host:8443/api/s/default/cmd/devmgr", payload={})
+    unifi_controller.connectivity.is_unifi_os = False
+    await unifi_controller.request(SpeedtestTriggerLegacyRequest.create())
+    assert unifi_called_with("post", "/api/s/default/cmd/devmgr", json={"cmd": "speedtest"})
+
+
+@pytest.mark.asyncio
+async def test_speedtest_handler_fetch_hardware(
+    mock_aioresponse: aioresponses, unifi_controller: Controller
+) -> None:
+    """Test hardware speedtest fetch returns most recent."""
+    mock_aioresponse.get(
+        "https://host:8443/proxy/network/v2/api/site/default/speedtest", 
+        payload=[
+            {"time": 100, "status": "completed", "download_mbps": 500, "upload_mbps": 100, "latency_ms": 10},
+            {"time": 150, "status": "failed", "download_mbps": 0, "upload_mbps": 0, "latency_ms": 0}
+        ]
+    )
+    unifi_controller.connectivity.is_unifi_os = True
+    status = await unifi_controller.speedtest.fetch()
+    assert status is not None
+    assert status.timestamp == 150
+    assert status.status == "failed"
+    assert status.download == 0
+    assert status.upload == 0
+    assert status.ping == 0
+
+
+@pytest.mark.asyncio
+async def test_speedtest_handler_fetch_hardware_empty(
+    mock_aioresponse: aioresponses, unifi_controller: Controller
+) -> None:
+    """Test hardware speedtest fetch empty data."""
+    mock_aioresponse.get("https://host:8443/proxy/network/v2/api/site/default/speedtest", payload=[])
+    unifi_controller.connectivity.is_unifi_os = True
+    status = await unifi_controller.speedtest.fetch()
+    assert status is None
+
+
+@pytest.mark.asyncio
+async def test_speedtest_handler_fetch_software(
+    mock_aioresponse: aioresponses, unifi_controller: Controller
+) -> None:
+    """Test software speedtest fetch returns www subsystem."""
+    mock_aioresponse.get(
+        "https://host:8443/api/s/default/stat/health", 
+        payload={
+            "data": [
+                {"subsystem": "lan", "status": "ok"},
+                {"subsystem": "www", "speedtest_lastrun": 200, "speedtest_status": "completed", "xput_down": 400, "xput_up": 200, "speedtest_ping": 15}
+            ]
+        }
+    )
+    unifi_controller.connectivity.is_unifi_os = False
+    status = await unifi_controller.speedtest.fetch()
+    assert status is not None
+    assert status.timestamp == 200
+    assert status.status == "completed"
+    assert status.download == 400
+    assert status.upload == 200
+    assert status.ping == 15
+
+
+@pytest.mark.asyncio
+async def test_speedtest_handler_fetch_software_empty(
+    mock_aioresponse: aioresponses, unifi_controller: Controller
+) -> None:
+    """Test software speedtest fetch missing www subsystem."""
+    mock_aioresponse.get("https://host:8443/api/s/default/stat/health", payload={"data": [{"subsystem": "lan", "status": "ok"}]})
+    unifi_controller.connectivity.is_unifi_os = False
+    status = await unifi_controller.speedtest.fetch()
+    assert status is None
+
+
+@pytest.mark.asyncio
+async def test_speedtest_handler_trigger_hardware(
+    mock_aioresponse: aioresponses,
+    unifi_controller: Controller,
+    unifi_called_with: Callable[..., bool],
+) -> None:
+    """Test hardware speedtest trigger function."""
+    mock_aioresponse.post("https://host:8443/proxy/network/api/s/default/cmd/devmgr/speedtest", payload={})
+    unifi_controller.connectivity.is_unifi_os = True
+    await unifi_controller.speedtest.trigger()
+    assert unifi_called_with("post", "/api/s/default/cmd/devmgr/speedtest")
+
+
+@pytest.mark.asyncio
+async def test_speedtest_handler_trigger_software(
+    mock_aioresponse: aioresponses,
+    unifi_controller: Controller,
+    unifi_called_with: Callable[..., bool],
+) -> None:
+    """Test software speedtest trigger function."""
+    mock_aioresponse.post("https://host:8443/api/s/default/cmd/devmgr", payload={})
+    unifi_controller.connectivity.is_unifi_os = False
+    await unifi_controller.speedtest.trigger()
+    assert unifi_called_with("post", "/api/s/default/cmd/devmgr", json={"cmd": "speedtest"})

--- a/tests/test_speedtest.py
+++ b/tests/test_speedtest.py
@@ -3,9 +3,10 @@
 from collections.abc import Callable
 
 from aioresponses import aioresponses
+import pytest
+
 from aiounifi.controller import Controller
 from aiounifi.models.speedtest import SpeedtestStatusRequest, SpeedtestTriggerRequest
-import pytest
 
 
 @pytest.mark.asyncio
@@ -48,19 +49,27 @@ async def test_speedtest_handler_update(
         payload=[
             {
                 "id": "1",
+                "interface_name": "eth2",
                 "time": 100,
-                "status": "completed",
                 "download_mbps": 500,
                 "upload_mbps": 100,
                 "latency_ms": 10,
             },
             {
                 "id": "2",
+                "interface_name": "eth1",
                 "time": 150,
-                "status": "failed",
                 "download_mbps": 0,
                 "upload_mbps": 0,
                 "latency_ms": 0,
+            },
+            {
+                "id": "3",
+                "interface_name": "eth2",
+                "time": 200,
+                "download_mbps": 800,
+                "upload_mbps": 200,
+                "latency_ms": 15,
             },
         ],
     )
@@ -68,45 +77,25 @@ async def test_speedtest_handler_update(
     await unifi_controller.speedtest.update()
 
     assert len(unifi_controller.speedtest.values()) == 2
-    status = unifi_controller.speedtest["2"]
-    assert status.timestamp == 150
-    assert status.status == "failed"
-    assert status.download == 0
-    assert status.upload == 0
-    assert status.ping == 0
+
+    status_eth2 = unifi_controller.speedtest["eth2"]
+    assert status_eth2.timestamp == 200
+    assert status_eth2.download == 800
+    assert status_eth2.upload == 200
+    assert status_eth2.ping == 15
+
+    status_eth1 = unifi_controller.speedtest["eth1"]
+    assert status_eth1.timestamp == 150
+    assert status_eth1.download == 0
+    assert status_eth1.upload == 0
+    assert status_eth1.ping == 0
 
 
 @pytest.mark.asyncio
-async def test_speedtest_handler_update_implicit_status(
+async def test_speedtest_handler_update_unknown(
     mock_aioresponse: aioresponses, unifi_controller: Controller
 ) -> None:
-    """Test speedtest update returns Completed when no explicit status is provided."""
-    mock_aioresponse.get(
-        "https://host:8443/proxy/network/v2/api/site/default/speedtest",
-        payload=[
-            {
-                "id": "1",
-                "time": 200,
-                "download_mbps": 1000,
-                "upload_mbps": 500,
-                "latency_ms": 20,
-            }
-        ],
-    )
-    unifi_controller.connectivity.is_unifi_os = True
-    await unifi_controller.speedtest.update()
-
-    assert len(unifi_controller.speedtest.values()) == 1
-    status = unifi_controller.speedtest["1"]
-    assert status.status == "Completed"
-    assert status.download == 1000
-
-
-@pytest.mark.asyncio
-async def test_speedtest_handler_update_implicit_unknown(
-    mock_aioresponse: aioresponses, unifi_controller: Controller
-) -> None:
-    """Test speedtest update returns unknown when no speeds exist either."""
+    """Test speedtest values return unknown when no speeds exist."""
     mock_aioresponse.get(
         "https://host:8443/proxy/network/v2/api/site/default/speedtest",
         payload=[{"id": "1", "time": 200}],
@@ -114,8 +103,9 @@ async def test_speedtest_handler_update_implicit_unknown(
     unifi_controller.connectivity.is_unifi_os = True
     await unifi_controller.speedtest.update()
 
-    status = unifi_controller.speedtest["1"]
-    assert status.status == "unknown"
+    status = unifi_controller.speedtest["default"]
+    assert status.upload == 0.0
+    assert status.download == 0.0
 
 
 @pytest.mark.asyncio
@@ -144,34 +134,3 @@ async def test_speedtest_handler_trigger(
     unifi_controller.connectivity.is_unifi_os = True
     await unifi_controller.speedtest.trigger()
     assert unifi_called_with("post", "/api/s/default/cmd/devmgr/speedtest")
-
-
-@pytest.mark.asyncio
-async def test_speedtest_handler_update_nested(
-    mock_aioresponse: aioresponses, unifi_controller: Controller
-) -> None:
-    """Test speedtest update with nested data structure."""
-    mock_aioresponse.get(
-        "https://host:8443/proxy/network/v2/api/site/default/speedtest",
-        payload=[
-            {
-                "data": [
-                    {
-                        "id": "1",
-                        "time": 300,
-                        "status": "completed",
-                        "download_mbps": 800,
-                        "upload_mbps": 400,
-                        "latency_ms": 15,
-                    }
-                ]
-            }
-        ],
-    )
-    unifi_controller.connectivity.is_unifi_os = True
-    await unifi_controller.speedtest.update()
-
-    assert len(unifi_controller.speedtest.values()) == 1
-    status = unifi_controller.speedtest["1"]
-    assert status.timestamp == 300
-    assert status.download == 800

--- a/tests/test_speedtest.py
+++ b/tests/test_speedtest.py
@@ -1,11 +1,8 @@
 """Test speedtest API."""
 
 from collections.abc import Callable
-from typing import Any
 
 from aioresponses import aioresponses
-import pytest
-
 from aiounifi.controller import Controller
 from aiounifi.models.speedtest import (
     SpeedtestStatusLegacyRequest,
@@ -13,6 +10,7 @@ from aiounifi.models.speedtest import (
     SpeedtestTriggerLegacyRequest,
     SpeedtestTriggerRequest,
 )
+import pytest
 
 
 @pytest.mark.asyncio
@@ -22,7 +20,9 @@ async def test_speedtest_status_hardware_request(
     unifi_called_with: Callable[..., bool],
 ) -> None:
     """Test hardware speedtest status."""
-    mock_aioresponse.get("https://host:8443/proxy/network/v2/api/site/default/speedtest", payload=[])
+    mock_aioresponse.get(
+        "https://host:8443/proxy/network/v2/api/site/default/speedtest", payload=[]
+    )
     unifi_controller.connectivity.is_unifi_os = True
     await unifi_controller.request(SpeedtestStatusRequest.create())
     assert unifi_called_with("get", "/v2/api/site/default/speedtest")
@@ -48,7 +48,9 @@ async def test_speedtest_trigger_hardware_request(
     unifi_called_with: Callable[..., bool],
 ) -> None:
     """Test hardware speedtest trigger."""
-    mock_aioresponse.post("https://host:8443/proxy/network/api/s/default/cmd/devmgr/speedtest", payload={})
+    mock_aioresponse.post(
+        "https://host:8443/proxy/network/api/s/default/cmd/devmgr/speedtest", payload={}
+    )
     unifi_controller.connectivity.is_unifi_os = True
     await unifi_controller.request(SpeedtestTriggerRequest.create())
     assert unifi_called_with("post", "/api/s/default/cmd/devmgr/speedtest")
@@ -64,7 +66,9 @@ async def test_speedtest_trigger_software_request(
     mock_aioresponse.post("https://host:8443/api/s/default/cmd/devmgr", payload={})
     unifi_controller.connectivity.is_unifi_os = False
     await unifi_controller.request(SpeedtestTriggerLegacyRequest.create())
-    assert unifi_called_with("post", "/api/s/default/cmd/devmgr", json={"cmd": "speedtest"})
+    assert unifi_called_with(
+        "post", "/api/s/default/cmd/devmgr", json={"cmd": "speedtest"}
+    )
 
 
 @pytest.mark.asyncio
@@ -73,11 +77,23 @@ async def test_speedtest_handler_fetch_hardware(
 ) -> None:
     """Test hardware speedtest fetch returns most recent."""
     mock_aioresponse.get(
-        "https://host:8443/proxy/network/v2/api/site/default/speedtest", 
+        "https://host:8443/proxy/network/v2/api/site/default/speedtest",
         payload=[
-            {"time": 100, "status": "completed", "download_mbps": 500, "upload_mbps": 100, "latency_ms": 10},
-            {"time": 150, "status": "failed", "download_mbps": 0, "upload_mbps": 0, "latency_ms": 0}
-        ]
+            {
+                "time": 100,
+                "status": "completed",
+                "download_mbps": 500,
+                "upload_mbps": 100,
+                "latency_ms": 10,
+            },
+            {
+                "time": 150,
+                "status": "failed",
+                "download_mbps": 0,
+                "upload_mbps": 0,
+                "latency_ms": 0,
+            },
+        ],
     )
     unifi_controller.connectivity.is_unifi_os = True
     status = await unifi_controller.speedtest.fetch()
@@ -90,11 +106,51 @@ async def test_speedtest_handler_fetch_hardware(
 
 
 @pytest.mark.asyncio
+async def test_speedtest_handler_fetch_hardware_implicit_status(
+    mock_aioresponse: aioresponses, unifi_controller: Controller
+) -> None:
+    """Test hardware speedtest fetch returns Completed when no explicit status is provided."""
+    mock_aioresponse.get(
+        "https://host:8443/proxy/network/v2/api/site/default/speedtest",
+        payload=[
+            {
+                "time": 200,
+                "download_mbps": 1000,
+                "upload_mbps": 500,
+                "latency_ms": 20,
+            }
+        ],
+    )
+    unifi_controller.connectivity.is_unifi_os = True
+    status = await unifi_controller.speedtest.fetch()
+    assert status is not None
+    assert status.status == "Completed"
+    assert status.download == 1000
+
+
+@pytest.mark.asyncio
+async def test_speedtest_handler_fetch_hardware_implicit_unknown(
+    mock_aioresponse: aioresponses, unifi_controller: Controller
+) -> None:
+    """Test hardware speedtest fetch returns unknown when no speeds exist either."""
+    mock_aioresponse.get(
+        "https://host:8443/proxy/network/v2/api/site/default/speedtest",
+        payload=[{"time": 200}],
+    )
+    unifi_controller.connectivity.is_unifi_os = True
+    status = await unifi_controller.speedtest.fetch()
+    assert status is not None
+    assert status.status == "unknown"
+
+
+@pytest.mark.asyncio
 async def test_speedtest_handler_fetch_hardware_empty(
     mock_aioresponse: aioresponses, unifi_controller: Controller
 ) -> None:
     """Test hardware speedtest fetch empty data."""
-    mock_aioresponse.get("https://host:8443/proxy/network/v2/api/site/default/speedtest", payload=[])
+    mock_aioresponse.get(
+        "https://host:8443/proxy/network/v2/api/site/default/speedtest", payload=[]
+    )
     unifi_controller.connectivity.is_unifi_os = True
     status = await unifi_controller.speedtest.fetch()
     assert status is None
@@ -106,13 +162,20 @@ async def test_speedtest_handler_fetch_software(
 ) -> None:
     """Test software speedtest fetch returns www subsystem."""
     mock_aioresponse.get(
-        "https://host:8443/api/s/default/stat/health", 
+        "https://host:8443/api/s/default/stat/health",
         payload={
             "data": [
                 {"subsystem": "lan", "status": "ok"},
-                {"subsystem": "www", "speedtest_lastrun": 200, "speedtest_status": "completed", "xput_down": 400, "xput_up": 200, "speedtest_ping": 15}
+                {
+                    "subsystem": "www",
+                    "speedtest_lastrun": 200,
+                    "speedtest_status": "completed",
+                    "xput_down": 400,
+                    "xput_up": 200,
+                    "speedtest_ping": 15,
+                },
             ]
-        }
+        },
     )
     unifi_controller.connectivity.is_unifi_os = False
     status = await unifi_controller.speedtest.fetch()
@@ -129,7 +192,10 @@ async def test_speedtest_handler_fetch_software_empty(
     mock_aioresponse: aioresponses, unifi_controller: Controller
 ) -> None:
     """Test software speedtest fetch missing www subsystem."""
-    mock_aioresponse.get("https://host:8443/api/s/default/stat/health", payload={"data": [{"subsystem": "lan", "status": "ok"}]})
+    mock_aioresponse.get(
+        "https://host:8443/api/s/default/stat/health",
+        payload={"data": [{"subsystem": "lan", "status": "ok"}]},
+    )
     unifi_controller.connectivity.is_unifi_os = False
     status = await unifi_controller.speedtest.fetch()
     assert status is None
@@ -142,7 +208,9 @@ async def test_speedtest_handler_trigger_hardware(
     unifi_called_with: Callable[..., bool],
 ) -> None:
     """Test hardware speedtest trigger function."""
-    mock_aioresponse.post("https://host:8443/proxy/network/api/s/default/cmd/devmgr/speedtest", payload={})
+    mock_aioresponse.post(
+        "https://host:8443/proxy/network/api/s/default/cmd/devmgr/speedtest", payload={}
+    )
     unifi_controller.connectivity.is_unifi_os = True
     await unifi_controller.speedtest.trigger()
     assert unifi_called_with("post", "/api/s/default/cmd/devmgr/speedtest")
@@ -158,4 +226,6 @@ async def test_speedtest_handler_trigger_software(
     mock_aioresponse.post("https://host:8443/api/s/default/cmd/devmgr", payload={})
     unifi_controller.connectivity.is_unifi_os = False
     await unifi_controller.speedtest.trigger()
-    assert unifi_called_with("post", "/api/s/default/cmd/devmgr", json={"cmd": "speedtest"})
+    assert unifi_called_with(
+        "post", "/api/s/default/cmd/devmgr", json={"cmd": "speedtest"}
+    )

--- a/tests/test_speedtest.py
+++ b/tests/test_speedtest.py
@@ -71,6 +71,14 @@ async def test_speedtest_handler_update(
                 "upload_mbps": 200,
                 "latency_ms": 15,
             },
+            {
+                "id": "4",
+                "interface_name": "eth2",
+                "time": 50,
+                "download_mbps": 100,
+                "upload_mbps": 50,
+                "latency_ms": 20,
+            },
         ],
     )
     unifi_controller.connectivity.is_unifi_os = True
@@ -134,3 +142,37 @@ async def test_speedtest_handler_trigger(
     unifi_controller.connectivity.is_unifi_os = True
     await unifi_controller.speedtest.trigger()
     assert unifi_called_with("post", "/api/s/default/cmd/devmgr/speedtest")
+
+
+@pytest.mark.asyncio
+async def test_speedtest_handler_update_nested_data(
+    mock_aioresponse: aioresponses, unifi_controller: Controller
+) -> None:
+    """Test speedtest update with nested data structure."""
+    mock_aioresponse.get(
+        "https://host:8443/proxy/network/v2/api/site/default/speedtest",
+        payload=[
+            {
+                "data": [
+                    {
+                        "id": "1",
+                        "interface_name": "eth0",
+                        "time": 300,
+                        "download_mbps": 900,
+                        "upload_mbps": 300,
+                        "latency_ms": 5,
+                    }
+                ]
+            }
+        ],
+    )
+    unifi_controller.connectivity.is_unifi_os = True
+    await unifi_controller.speedtest.update()
+
+    assert len(unifi_controller.speedtest.values()) == 1
+
+    status = unifi_controller.speedtest["eth0"]
+    assert status.timestamp == 300
+    assert status.download == 900
+    assert status.upload == 300
+    assert status.ping == 5


### PR DESCRIPTION
This exposes UniFI speedtest results by calling the (undocumented?) `/speedtest` API endpoint. It also allows triggering a speedtest using the `/cmd/devmgr/speedtest` API endpoint. This exposes only the most recent speedtest result from the API call. Dual-WAN support at this time is *unknown*.

This only supports newer controllers that have these API endpoints. The (now "old") stand-alone UniFi Network Application doesn't support these newer API endpoints. Works with the new UniFi OS Server and I assume other cloud gateway hardware appliances that aren't EOL.

This will allow exposing speedtest results in Home Assistant's native UniFi integration.