### PR TITLE
Add object-oriented network config support

### DIFF
--- a/aiounifi/controller.py
+++ b/aiounifi/controller.py
@@ -15,6 +15,7 @@ from .interfaces.events import EventHandler
 from .interfaces.firewall_policies import FirewallPolicies
 from .interfaces.firewall_zones import FirewallZones
 from .interfaces.messages import MessageHandler
+from .interfaces.object_oriented_network_configs import ObjectOrientedNetworkConfigs
 from .interfaces.outlets import Outlets
 from .interfaces.port_forwarding import PortForwarding
 from .interfaces.ports import Ports
@@ -49,6 +50,7 @@ class Controller:
         self.dpi_groups = DPIRestrictionGroups(self)
         self.firewall_zones = FirewallZones(self)
         self.firewall_policies = FirewallPolicies(self)
+        self.object_oriented_network_configs = ObjectOrientedNetworkConfigs(self)
         self.outlets = Outlets(self)
         self.port_forwarding = PortForwarding(self)
         self.ports = Ports(self)

--- a/aiounifi/interfaces/api_handlers.py
+++ b/aiounifi/interfaces/api_handlers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC
 from collections.abc import Callable, ItemsView, Iterator, ValuesView
 import enum
-from typing import TYPE_CHECKING, Any, Generic, final
+from typing import TYPE_CHECKING, Any, Generic, cast, final
 
 from ..models.api import ApiItemT, ApiRequest
 
@@ -110,6 +110,17 @@ class APIHandler(SubscriptionHandler, Generic[ApiItemT]):
         for raw_item in raw:
             self.process_item(raw_item)
 
+    def _obj_id_from_raw(self, raw: dict[str, Any]) -> str | None:
+        """Return object ID from raw data."""
+        if self.obj_id_key in raw:
+            return cast(str, raw[self.obj_id_key])
+
+        if self.alt_obj_id_key is None or self.alt_obj_id_key not in raw:
+            return None
+
+        raw[self.obj_id_key] = raw[self.alt_obj_id_key]
+        return cast(str, raw[self.obj_id_key])
+
     @final
     def process_message(self, message: Message) -> None:
         """Process and forward websocket data."""
@@ -122,17 +133,10 @@ class APIHandler(SubscriptionHandler, Generic[ApiItemT]):
     @final
     def process_item(self, raw: dict[str, Any]) -> None:
         """Process item data."""
-        obj_id_key = self.obj_id_key
-        if obj_id_key not in raw:
-            if self.alt_obj_id_key is None or self.alt_obj_id_key not in raw:
-                return
-            obj_id_key = self.alt_obj_id_key
+        if (obj_id := self._obj_id_from_raw(raw)) is None:
+            return
 
-        if self.obj_id_key not in raw:
-            raw[self.obj_id_key] = raw[obj_id_key]
-
-        obj_id: str
-        obj_is_known = (obj_id := raw[obj_id_key]) in self._items
+        obj_is_known = obj_id in self._items
         self._items[obj_id] = self.item_cls(raw)
 
         self.signal_subscribers(
@@ -143,8 +147,10 @@ class APIHandler(SubscriptionHandler, Generic[ApiItemT]):
     @final
     def remove_item(self, raw: dict[str, Any]) -> None:
         """Remove item."""
-        obj_id: str
-        if (obj_id := raw[self.obj_id_key]) in self._items:
+        if (obj_id := self._obj_id_from_raw(raw)) is None:
+            return
+
+        if obj_id in self._items:
             self._items.pop(obj_id)
             self.signal_subscribers(ItemEvent.DELETED, obj_id)
 

--- a/aiounifi/interfaces/api_handlers.py
+++ b/aiounifi/interfaces/api_handlers.py
@@ -83,6 +83,7 @@ class APIHandler(SubscriptionHandler, Generic[ApiItemT]):
     """Base class for a map of API Items."""
 
     obj_id_key: str
+    alt_obj_id_key: str | None = None
     item_cls: type[ApiItemT]
     api_request: ApiRequest
     process_messages: tuple[MessageKey, ...] = ()
@@ -121,11 +122,17 @@ class APIHandler(SubscriptionHandler, Generic[ApiItemT]):
     @final
     def process_item(self, raw: dict[str, Any]) -> None:
         """Process item data."""
+        obj_id_key = self.obj_id_key
+        if obj_id_key not in raw:
+            if self.alt_obj_id_key is None or self.alt_obj_id_key not in raw:
+                return
+            obj_id_key = self.alt_obj_id_key
+
         if self.obj_id_key not in raw:
-            return
+            raw[self.obj_id_key] = raw[obj_id_key]
 
         obj_id: str
-        obj_is_known = (obj_id := raw[self.obj_id_key]) in self._items
+        obj_is_known = (obj_id := raw[obj_id_key]) in self._items
         self._items[obj_id] = self.item_cls(raw)
 
         self.signal_subscribers(

--- a/aiounifi/interfaces/api_handlers.py
+++ b/aiounifi/interfaces/api_handlers.py
@@ -82,8 +82,7 @@ class SubscriptionHandler(ABC):
 class APIHandler(SubscriptionHandler, Generic[ApiItemT]):
     """Base class for a map of API Items."""
 
-    obj_id_key: str
-    alt_obj_id_key: str | None = None
+    obj_id_key: str | tuple[str, ...]
     item_cls: type[ApiItemT]
     api_request: ApiRequest
     process_messages: tuple[MessageKey, ...] = ()
@@ -112,14 +111,15 @@ class APIHandler(SubscriptionHandler, Generic[ApiItemT]):
 
     def _obj_id_from_raw(self, raw: dict[str, Any]) -> str | None:
         """Return object ID from raw data."""
-        if self.obj_id_key in raw:
-            return cast(str, raw[self.obj_id_key])
+        obj_id_keys = (
+            (self.obj_id_key,) if isinstance(self.obj_id_key, str) else self.obj_id_key
+        )
+        obj_id_key = next((key for key in obj_id_keys if key in raw), None)
 
-        if self.alt_obj_id_key is None or self.alt_obj_id_key not in raw:
+        if obj_id_key is None:
             return None
 
-        raw[self.obj_id_key] = raw[self.alt_obj_id_key]
-        return cast(str, raw[self.obj_id_key])
+        return cast(str, raw[obj_id_key])
 
     @final
     def process_message(self, message: Message) -> None:

--- a/aiounifi/interfaces/object_oriented_network_configs.py
+++ b/aiounifi/interfaces/object_oriented_network_configs.py
@@ -1,0 +1,38 @@
+"""Object-oriented network configurations as part of a UniFi network."""
+
+from copy import deepcopy
+
+from ..models.api import TypedApiResponse
+from ..models.object_oriented_network_config import (
+    ObjectOrientedNetworkConfig,
+    ObjectOrientedNetworkConfigListRequest,
+    ObjectOrientedNetworkConfigUpdateRequest,
+)
+from .api_handlers import APIHandler
+
+
+class ObjectOrientedNetworkConfigs(APIHandler[ObjectOrientedNetworkConfig]):
+    """Represents object-oriented network configurations."""
+
+    obj_id_key = "_id"
+    item_cls = ObjectOrientedNetworkConfig
+    api_request = ObjectOrientedNetworkConfigListRequest.create()
+
+    async def enable(self, config: ObjectOrientedNetworkConfig) -> TypedApiResponse:
+        """Enable object-oriented network configuration."""
+        return await self.save(config, state=True)
+
+    async def disable(self, config: ObjectOrientedNetworkConfig) -> TypedApiResponse:
+        """Disable object-oriented network configuration."""
+        return await self.save(config, state=False)
+
+    async def save(
+        self, config: ObjectOrientedNetworkConfig, state: bool | None = None
+    ) -> TypedApiResponse:
+        """Set object-oriented network configuration to the desired state."""
+        config_dict = deepcopy(config.raw)
+        config_response = await self.controller.request(
+            ObjectOrientedNetworkConfigUpdateRequest.create(config_dict, enable=state)
+        )
+        self.process_raw(config_response.get("data", []))
+        return config_response

--- a/aiounifi/interfaces/object_oriented_network_configs.py
+++ b/aiounifi/interfaces/object_oriented_network_configs.py
@@ -14,8 +14,7 @@ from .api_handlers import APIHandler
 class ObjectOrientedNetworkConfigs(APIHandler[ObjectOrientedNetworkConfig]):
     """Represents object-oriented network configurations."""
 
-    obj_id_key = "_id"
-    alt_obj_id_key = "id"
+    obj_id_key = ("_id", "id")
     item_cls = ObjectOrientedNetworkConfig
     api_request = ObjectOrientedNetworkConfigListRequest.create()
 

--- a/aiounifi/interfaces/object_oriented_network_configs.py
+++ b/aiounifi/interfaces/object_oriented_network_configs.py
@@ -15,6 +15,7 @@ class ObjectOrientedNetworkConfigs(APIHandler[ObjectOrientedNetworkConfig]):
     """Represents object-oriented network configurations."""
 
     obj_id_key = "_id"
+    alt_obj_id_key = "id"
     item_cls = ObjectOrientedNetworkConfig
     api_request = ObjectOrientedNetworkConfigListRequest.create()
 

--- a/aiounifi/models/object_oriented_network_config.py
+++ b/aiounifi/models/object_oriented_network_config.py
@@ -36,11 +36,12 @@ class ObjectOrientedNetworkRoute(TypedDict):
 class TypedObjectOrientedNetworkConfig(TypedDict):
     """Object-oriented network configuration type definition."""
 
-    _id: str
+    _id: NotRequired[str]
+    id: NotRequired[str]
     enabled: bool
     name: str
     target_type: NotRequired[str]
-    targets: NotRequired[list[str]]
+    targets: NotRequired[list[Any]]
     qos: NotRequired[ObjectOrientedNetworkQos]
     route: NotRequired[ObjectOrientedNetworkRoute]
     secure: NotRequired[ObjectOrientedNetworkSecure]
@@ -69,7 +70,7 @@ class ObjectOrientedNetworkConfigUpdateRequest(ApiRequestV2):
             config["enabled"] = enable
         return cls(
             method="put",
-            path=f"/object-oriented-network-config/{config['_id']}",
+            path=f"/object-oriented-network-config/{config.get('_id') or config['id']}",
             data=config,
         )
 
@@ -82,7 +83,7 @@ class ObjectOrientedNetworkConfig(ApiItem):
     @property
     def id(self) -> str:
         """ID of object-oriented network configuration."""
-        return self.raw["_id"]
+        return self.raw.get("_id") or self.raw["id"]
 
     @property
     def name(self) -> str:
@@ -100,7 +101,7 @@ class ObjectOrientedNetworkConfig(ApiItem):
         return self.raw.get("target_type", "CLIENTS")
 
     @property
-    def targets(self) -> list[str]:
+    def targets(self) -> list[Any]:
         """Targets affected by object-oriented network configuration."""
         return self.raw.get("targets", [])
 

--- a/aiounifi/models/object_oriented_network_config.py
+++ b/aiounifi/models/object_oriented_network_config.py
@@ -108,14 +108,17 @@ class ObjectOrientedNetworkConfig(ApiItem):
     @property
     def secure(self) -> ObjectOrientedNetworkSecure:
         """Security configuration."""
-        return self.raw.get("secure", {"enabled": False})
+        default: ObjectOrientedNetworkSecure = {"enabled": False}
+        return self.raw.get("secure", default)
 
     @property
     def qos(self) -> ObjectOrientedNetworkQos:
         """QoS configuration."""
-        return self.raw.get("qos", {"enabled": False})
+        default: ObjectOrientedNetworkQos = {"enabled": False}
+        return self.raw.get("qos", default)
 
     @property
     def route(self) -> ObjectOrientedNetworkRoute:
         """Routing configuration."""
-        return self.raw.get("route", {"enabled": False})
+        default: ObjectOrientedNetworkRoute = {"enabled": False}
+        return self.raw.get("route", default)

--- a/aiounifi/models/object_oriented_network_config.py
+++ b/aiounifi/models/object_oriented_network_config.py
@@ -109,16 +109,16 @@ class ObjectOrientedNetworkConfig(ApiItem):
     def secure(self) -> ObjectOrientedNetworkSecure:
         """Security configuration."""
         default: ObjectOrientedNetworkSecure = {"enabled": False}
-        return self.raw.get("secure", default)
+        return default | self.raw.get("secure", {})
 
     @property
     def qos(self) -> ObjectOrientedNetworkQos:
         """QoS configuration."""
         default: ObjectOrientedNetworkQos = {"enabled": False}
-        return self.raw.get("qos", default)
+        return default | self.raw.get("qos", {})
 
     @property
     def route(self) -> ObjectOrientedNetworkRoute:
         """Routing configuration."""
         default: ObjectOrientedNetworkRoute = {"enabled": False}
-        return self.raw.get("route", default)
+        return default | self.raw.get("route", {})

--- a/aiounifi/models/object_oriented_network_config.py
+++ b/aiounifi/models/object_oriented_network_config.py
@@ -1,0 +1,120 @@
+"""Object-oriented network configurations as part of a UniFi network."""
+
+from dataclasses import dataclass
+from typing import Any, NotRequired, Self, TypedDict
+
+from .api import ApiItem, ApiRequestV2
+
+
+class ObjectOrientedNetworkInternet(TypedDict):
+    """Internet access configuration."""
+
+    mode: str
+    schedule: dict[str, Any]
+
+
+class ObjectOrientedNetworkSecure(TypedDict):
+    """Security configuration."""
+
+    enabled: bool
+    internet: ObjectOrientedNetworkInternet
+
+
+class ObjectOrientedNetworkQos(TypedDict):
+    """QoS configuration."""
+
+    enabled: bool
+
+
+class ObjectOrientedNetworkRoute(TypedDict):
+    """Routing configuration."""
+
+    enabled: bool
+    kill_switch: NotRequired[bool]
+
+
+class TypedObjectOrientedNetworkConfig(TypedDict):
+    """Object-oriented network configuration type definition."""
+
+    _id: str
+    enabled: bool
+    name: str
+    target_type: str
+    targets: list[str]
+    qos: ObjectOrientedNetworkQos
+    route: ObjectOrientedNetworkRoute
+    secure: ObjectOrientedNetworkSecure
+
+
+@dataclass
+class ObjectOrientedNetworkConfigListRequest(ApiRequestV2):
+    """Request object for object-oriented network configuration list."""
+
+    @classmethod
+    def create(cls) -> Self:
+        """Create object-oriented network configuration request."""
+        return cls(method="get", path="/object-oriented-network-configs", data=None)
+
+
+@dataclass
+class ObjectOrientedNetworkConfigUpdateRequest(ApiRequestV2):
+    """Request object for object-oriented network configuration update."""
+
+    @classmethod
+    def create(
+        cls, config: TypedObjectOrientedNetworkConfig, enable: bool | None = None
+    ) -> Self:
+        """Create object-oriented network configuration update request."""
+        if enable is not None:
+            config["enabled"] = enable
+        return cls(
+            method="put",
+            path=f"/object-oriented-network-config/{config['_id']}",
+            data=config,
+        )
+
+
+class ObjectOrientedNetworkConfig(ApiItem):
+    """Represent an object-oriented network configuration."""
+
+    raw: TypedObjectOrientedNetworkConfig
+
+    @property
+    def id(self) -> str:
+        """ID of object-oriented network configuration."""
+        return self.raw["_id"]
+
+    @property
+    def name(self) -> str:
+        """Name of object-oriented network configuration."""
+        return self.raw["name"]
+
+    @property
+    def enabled(self) -> bool:
+        """Is object-oriented network configuration enabled."""
+        return self.raw["enabled"]
+
+    @property
+    def target_type(self) -> str:
+        """Target type for object-oriented network configuration."""
+        return self.raw["target_type"]
+
+    @property
+    def targets(self) -> list[str]:
+        """Targets affected by object-oriented network configuration."""
+        return self.raw["targets"]
+
+    @property
+    def secure(self) -> ObjectOrientedNetworkSecure:
+        """Security configuration."""
+        return self.raw["secure"]
+
+    @property
+    def qos(self) -> ObjectOrientedNetworkQos:
+        """QoS configuration."""
+        return self.raw["qos"]
+
+    @property
+    def route(self) -> ObjectOrientedNetworkRoute:
+        """Routing configuration."""
+        return self.raw["route"]

--- a/aiounifi/models/object_oriented_network_config.py
+++ b/aiounifi/models/object_oriented_network_config.py
@@ -10,26 +10,26 @@ class ObjectOrientedNetworkInternet(TypedDict):
     """Internet access configuration."""
 
     mode: str
-    schedule: dict[str, Any]
+    schedule: NotRequired[dict[str, Any]]
 
 
 class ObjectOrientedNetworkSecure(TypedDict):
     """Security configuration."""
 
-    enabled: bool
-    internet: ObjectOrientedNetworkInternet
+    enabled: NotRequired[bool]
+    internet: NotRequired[ObjectOrientedNetworkInternet]
 
 
 class ObjectOrientedNetworkQos(TypedDict):
     """QoS configuration."""
 
-    enabled: bool
+    enabled: NotRequired[bool]
 
 
 class ObjectOrientedNetworkRoute(TypedDict):
     """Routing configuration."""
 
-    enabled: bool
+    enabled: NotRequired[bool]
     kill_switch: NotRequired[bool]
 
 
@@ -39,11 +39,11 @@ class TypedObjectOrientedNetworkConfig(TypedDict):
     _id: str
     enabled: bool
     name: str
-    target_type: str
-    targets: list[str]
-    qos: ObjectOrientedNetworkQos
-    route: ObjectOrientedNetworkRoute
-    secure: ObjectOrientedNetworkSecure
+    target_type: NotRequired[str]
+    targets: NotRequired[list[str]]
+    qos: NotRequired[ObjectOrientedNetworkQos]
+    route: NotRequired[ObjectOrientedNetworkRoute]
+    secure: NotRequired[ObjectOrientedNetworkSecure]
 
 
 @dataclass
@@ -97,24 +97,24 @@ class ObjectOrientedNetworkConfig(ApiItem):
     @property
     def target_type(self) -> str:
         """Target type for object-oriented network configuration."""
-        return self.raw["target_type"]
+        return self.raw.get("target_type", "CLIENTS")
 
     @property
     def targets(self) -> list[str]:
         """Targets affected by object-oriented network configuration."""
-        return self.raw["targets"]
+        return self.raw.get("targets", [])
 
     @property
     def secure(self) -> ObjectOrientedNetworkSecure:
         """Security configuration."""
-        return self.raw["secure"]
+        return self.raw.get("secure", {"enabled": False})
 
     @property
     def qos(self) -> ObjectOrientedNetworkQos:
         """QoS configuration."""
-        return self.raw["qos"]
+        return self.raw.get("qos", {"enabled": False})
 
     @property
     def route(self) -> ObjectOrientedNetworkRoute:
         """Routing configuration."""
-        return self.raw["route"]
+        return self.raw.get("route", {"enabled": False})

--- a/aiounifi/models/object_oriented_network_config.py
+++ b/aiounifi/models/object_oriented_network_config.py
@@ -1,7 +1,7 @@
 """Object-oriented network configurations as part of a UniFi network."""
 
 from dataclasses import dataclass
-from typing import Any, NotRequired, Self, TypedDict
+from typing import NotRequired, Self, TypedDict
 
 from .api import ApiItem, ApiRequestV2
 
@@ -10,7 +10,14 @@ class ObjectOrientedNetworkInternet(TypedDict):
     """Internet access configuration."""
 
     mode: str
-    schedule: NotRequired[dict[str, Any]]
+    schedule: NotRequired[dict[str, str]]
+
+
+class ObjectOrientedNetworkTarget(TypedDict):
+    """Target affected by object-oriented network configuration."""
+
+    type: str
+    value: str
 
 
 class ObjectOrientedNetworkSecure(TypedDict):
@@ -41,7 +48,7 @@ class TypedObjectOrientedNetworkConfig(TypedDict):
     enabled: bool
     name: str
     target_type: NotRequired[str]
-    targets: NotRequired[list[Any]]
+    targets: NotRequired[list[str | ObjectOrientedNetworkTarget]]
     qos: NotRequired[ObjectOrientedNetworkQos]
     route: NotRequired[ObjectOrientedNetworkRoute]
     secure: NotRequired[ObjectOrientedNetworkSecure]
@@ -96,12 +103,12 @@ class ObjectOrientedNetworkConfig(ApiItem):
         return self.raw["enabled"]
 
     @property
-    def target_type(self) -> str:
+    def target_type(self) -> str | None:
         """Target type for object-oriented network configuration."""
-        return self.raw.get("target_type", "CLIENTS")
+        return self.raw.get("target_type")
 
     @property
-    def targets(self) -> list[Any]:
+    def targets(self) -> list[str | ObjectOrientedNetworkTarget]:
         """Targets affected by object-oriented network configuration."""
         return self.raw.get("targets", [])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "aiounifi"
-version     = "91"
+version     = "90"
 license     = {text = "MIT"}
 description = "Python library for communicating with UniFi Network Controller API"
 readme      = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "aiounifi"
-version     = "90"
+version     = "91"
 license     = {text = "MIT"}
 description = "Python library for communicating with UniFi Network Controller API"
 readme      = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,7 @@ def _endpoint_fixture(
     dpi_group_payload: list[dict[str, Any]],
     firewall_policy_payload: list[dict[str, Any]],
     firewall_zone_payload: list[dict[str, Any]],
+    object_oriented_network_config_payload: list[dict[str, Any]],
     port_forward_payload: list[dict[str, Any]],
     site_payload: list[dict[str, Any]],
     system_information_payload: list[dict[str, Any]],
@@ -195,6 +196,11 @@ def _endpoint_fixture(
         "/proxy/network/v2/api/site/default/firewall/zone",
         firewall_zone_payload,
     )
+    mock_get_request(
+        "/v2/api/site/default/object-oriented-network-configs",
+        "/proxy/network/v2/api/site/default/object-oriented-network-configs",
+        object_oriented_network_config_payload,
+    )
 
 
 @pytest.fixture(name="response_payload")
@@ -290,4 +296,10 @@ def firewall_policy_data_fixture() -> list[dict[str, Any]]:
 @pytest.fixture(name="firewall_zone_payload")
 def firewall_zone_data_fixture() -> list[dict[str, Any]]:
     """Firewall zone data."""
+    return []
+
+
+@pytest.fixture(name="object_oriented_network_config_payload")
+def object_oriented_network_config_data_fixture() -> list[dict[str, Any]]:
+    """Object-oriented network configuration data."""
     return []

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -128,11 +128,10 @@ async def test_api_handler_subscriptions_id_filter():
     unsub()
 
 
-async def test_api_handler_alt_obj_id_key_remove_item():
-    """Test process and remove item with alternate object ID key."""
+async def test_api_handler_tuple_obj_id_key_remove_item():
+    """Test process and remove item with tuple object ID keys."""
     handler = APIHandler(Mock())
-    handler.obj_id_key = "key"
-    handler.alt_obj_id_key = "id"
+    handler.obj_id_key = ("key", "id")
     handler.item_cls = Mock()
 
     handler.subscribe(mock_subscribe_cb := Mock())
@@ -140,13 +139,13 @@ async def test_api_handler_alt_obj_id_key_remove_item():
     raw = {"id": "1"}
     handler.process_item(raw)
     mock_subscribe_cb.assert_called_with(ItemEvent.ADDED, "1")
-    assert raw["key"] == "1"
+    assert "key" not in raw
     assert "1" in handler
 
     remove_raw = {"id": "1"}
     handler.remove_item(remove_raw)
     mock_subscribe_cb.assert_called_with(ItemEvent.DELETED, "1")
-    assert remove_raw["key"] == "1"
+    assert "key" not in remove_raw
     assert "1" not in handler
 
     handler.remove_item({"id": "2"})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -126,3 +126,29 @@ async def test_api_handler_subscriptions_id_filter():
     assert mock_subscribe_cb.call_count == 3
 
     unsub()
+
+
+async def test_api_handler_alt_obj_id_key_remove_item():
+    """Test process and remove item with alternate object ID key."""
+    handler = APIHandler(Mock())
+    handler.obj_id_key = "key"
+    handler.alt_obj_id_key = "id"
+    handler.item_cls = Mock()
+
+    handler.subscribe(mock_subscribe_cb := Mock())
+
+    raw = {"id": "1"}
+    handler.process_item(raw)
+    mock_subscribe_cb.assert_called_with(ItemEvent.ADDED, "1")
+    assert raw["key"] == "1"
+    assert "1" in handler
+
+    remove_raw = {"id": "1"}
+    handler.remove_item(remove_raw)
+    mock_subscribe_cb.assert_called_with(ItemEvent.DELETED, "1")
+    assert remove_raw["key"] == "1"
+    assert "1" not in handler
+
+    handler.remove_item({"id": "2"})
+    handler.remove_item({})
+    assert mock_subscribe_cb.call_count == 2

--- a/tests/test_object_oriented_network_configs.py
+++ b/tests/test_object_oriented_network_configs.py
@@ -205,7 +205,7 @@ async def test_object_oriented_network_config_optional_section_defaults(
     await configs.update()
 
     config = configs["69f6b0a5e0e3ee2d4614cb5c"]
-    assert config.target_type == "CLIENTS"
+    assert config.target_type is None
     assert config.targets == []
     assert config.secure["enabled"] is False
     assert config.secure["internet"]["mode"] == "TURN_OFF_INTERNET"
@@ -245,4 +245,4 @@ async def test_object_oriented_network_config_id_alias(unifi_controller):
 
     config = configs["69f6b0a5e0e3ee2d4614cb5c"]
     assert config.id == "69f6b0a5e0e3ee2d4614cb5c"
-    assert config.raw["_id"] == "69f6b0a5e0e3ee2d4614cb5c"
+    assert config.raw["id"] == "69f6b0a5e0e3ee2d4614cb5c"

--- a/tests/test_object_oriented_network_configs.py
+++ b/tests/test_object_oriented_network_configs.py
@@ -184,12 +184,22 @@ async def test_object_oriented_network_configs(unifi_controller, unifi_called_wi
                 "_id": "69f6b0a5e0e3ee2d4614cb5c",
                 "enabled": True,
                 "name": "Nintendo Switch - Block Internet",
+                "secure": {
+                    "internet": {
+                        "mode": "TURN_OFF_INTERNET",
+                        "schedule": {"mode": "ALWAYS"},
+                    },
+                },
+                "qos": {},
+                "route": {"kill_switch": True},
             }
         ]
     ],
 )
 @pytest.mark.usefixtures("_mock_endpoints")
-async def test_object_oriented_network_config_optional_sections(unifi_controller):
+async def test_object_oriented_network_config_optional_section_defaults(
+    unifi_controller,
+):
     """Test optional object-oriented network configuration sections."""
     configs = unifi_controller.object_oriented_network_configs
     await configs.update()
@@ -198,8 +208,10 @@ async def test_object_oriented_network_config_optional_sections(unifi_controller
     assert config.target_type == "CLIENTS"
     assert config.targets == []
     assert config.secure["enabled"] is False
+    assert config.secure["internet"]["mode"] == "TURN_OFF_INTERNET"
     assert config.qos["enabled"] is False
     assert config.route["enabled"] is False
+    assert config.route["kill_switch"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_object_oriented_network_configs.py
+++ b/tests/test_object_oriented_network_configs.py
@@ -174,3 +174,29 @@ async def test_object_oriented_network_configs(unifi_controller, unifi_called_wi
     assert config.secure["internet"]["mode"] == "TURN_OFF_INTERNET"
     assert config.qos["enabled"] is False
     assert config.route["enabled"] is False
+
+
+@pytest.mark.parametrize(
+    "object_oriented_network_config_payload",
+    [
+        [
+            {
+                "_id": "69f6b0a5e0e3ee2d4614cb5c",
+                "enabled": True,
+                "name": "Nintendo Switch - Block Internet",
+            }
+        ]
+    ],
+)
+@pytest.mark.usefixtures("_mock_endpoints")
+async def test_object_oriented_network_config_optional_sections(unifi_controller):
+    """Test optional object-oriented network configuration sections."""
+    configs = unifi_controller.object_oriented_network_configs
+    await configs.update()
+
+    config = configs["69f6b0a5e0e3ee2d4614cb5c"]
+    assert config.target_type == "CLIENTS"
+    assert config.targets == []
+    assert config.secure["enabled"] is False
+    assert config.qos["enabled"] is False
+    assert config.route["enabled"] is False

--- a/tests/test_object_oriented_network_configs.py
+++ b/tests/test_object_oriented_network_configs.py
@@ -1,0 +1,176 @@
+"""Test object-oriented network configuration API.
+
+pytest --cov-report term-missing --cov=aiounifi.object_oriented_network_config tests/test_object_oriented_network_configs.py
+"""
+
+from copy import deepcopy
+
+import pytest
+
+from aiounifi.models.object_oriented_network_config import (
+    ObjectOrientedNetworkConfigUpdateRequest,
+)
+
+OBJECT_ORIENTED_NETWORK_CONFIGS = [
+    {
+        "_id": "69f6b0a5e0e3ee2d4614cb5c",
+        "enabled": True,
+        "name": "Nintendo Switch - Block Internet",
+        "target_type": "CLIENTS",
+        "targets": ["98:b6:e9:b4:4c:29"],
+        "secure": {
+            "enabled": True,
+            "internet": {
+                "mode": "TURN_OFF_INTERNET",
+                "schedule": {"mode": "ALWAYS"},
+            },
+        },
+        "qos": {"enabled": False},
+        "route": {"enabled": False},
+    },
+    {
+        "_id": "69f6b0eae0e3ee2d4614cb91",
+        "enabled": False,
+        "name": "TV - Block Internet",
+        "target_type": "CLIENTS",
+        "targets": ["64:ff:0a:f0:fb:ba"],
+        "secure": {
+            "enabled": True,
+            "internet": {
+                "mode": "TURN_OFF_INTERNET",
+                "schedule": {"mode": "ALWAYS"},
+            },
+        },
+        "qos": {"enabled": False},
+        "route": {"enabled": False},
+    },
+]
+
+
+@pytest.mark.parametrize("is_unifi_os", [True])
+@pytest.mark.parametrize("enable", [True, False])
+async def test_object_oriented_network_config_update_request(
+    mock_aioresponse, unifi_controller, unifi_called_with, enable
+):
+    """Test that object-oriented network configuration can be updated."""
+    config_enabled = deepcopy(OBJECT_ORIENTED_NETWORK_CONFIGS[0])
+    config_disabled = deepcopy(OBJECT_ORIENTED_NETWORK_CONFIGS[1])
+
+    config = config_disabled if enable else config_enabled
+    config_id = config["_id"]
+    mock_aioresponse.put(
+        (
+            "https://host:8443/proxy/network/v2/api/site/default"
+            f"/object-oriented-network-config/{config_id}"
+        ),
+        payload={
+            **OBJECT_ORIENTED_NETWORK_CONFIGS[0 if not enable else 1],
+            "enabled": enable,
+        },
+    )
+
+    await unifi_controller.request(
+        ObjectOrientedNetworkConfigUpdateRequest.create(config, enable)
+    )
+
+    config["enabled"] = enable
+    assert unifi_called_with(
+        "put",
+        f"/proxy/network/v2/api/site/default/object-oriented-network-config/{config_id}",
+        json=config,
+    )
+
+
+@pytest.mark.parametrize(
+    "object_oriented_network_config_payload", [OBJECT_ORIENTED_NETWORK_CONFIGS]
+)
+@pytest.mark.parametrize("is_unifi_os", [True])
+@pytest.mark.parametrize("enable", [True, False])
+@pytest.mark.usefixtures("_mock_endpoints")
+async def test_object_oriented_network_config_toggle(
+    mock_aioresponse, unifi_controller, enable
+):
+    """Test toggle method can enable and disable an object-oriented network configuration."""
+    configs = unifi_controller.object_oriented_network_configs
+    await configs.update()
+
+    config_id = OBJECT_ORIENTED_NETWORK_CONFIGS[0 if not enable else 1]["_id"]
+
+    mock_aioresponse.put(
+        (
+            "https://host:8443/proxy/network/v2/api/site/default"
+            f"/object-oriented-network-config/{config_id}"
+        ),
+        payload={
+            **OBJECT_ORIENTED_NETWORK_CONFIGS[0 if not enable else 1],
+            "enabled": enable,
+        },
+    )
+    await configs.save(configs[config_id], enable)
+    assert configs[config_id].enabled is enable
+
+
+@pytest.mark.parametrize(
+    "object_oriented_network_config_payload", [OBJECT_ORIENTED_NETWORK_CONFIGS]
+)
+@pytest.mark.parametrize("is_unifi_os", [True])
+@pytest.mark.parametrize("enable", [True, False])
+@pytest.mark.usefixtures("_mock_endpoints")
+async def test_object_oriented_network_config_enable_disable(
+    mock_aioresponse, unifi_controller, enable
+):
+    """Test individual methods for enabled and disabled."""
+    configs = unifi_controller.object_oriented_network_configs
+    await configs.update()
+
+    config_id = OBJECT_ORIENTED_NETWORK_CONFIGS[0 if not enable else 1]["_id"]
+    config_call = configs.enable if enable else configs.disable
+
+    mock_aioresponse.put(
+        (
+            "https://host:8443/proxy/network/v2/api/site/default"
+            f"/object-oriented-network-config/{config_id}"
+        ),
+        payload={
+            **OBJECT_ORIENTED_NETWORK_CONFIGS[0 if not enable else 1],
+            "enabled": enable,
+        },
+    )
+    await config_call(configs[config_id])
+    assert configs[config_id].enabled is enable
+
+
+@pytest.mark.parametrize("is_unifi_os", [True])
+@pytest.mark.usefixtures("_mock_endpoints")
+async def test_no_object_oriented_network_configs(unifi_controller, unifi_called_with):
+    """Test that no object-oriented network configurations also work."""
+    configs = unifi_controller.object_oriented_network_configs
+    await configs.update()
+    assert unifi_called_with(
+        "get", "/proxy/network/v2/api/site/default/object-oriented-network-configs"
+    )
+    assert len(configs.values()) == 0
+
+
+@pytest.mark.parametrize(
+    "object_oriented_network_config_payload", [OBJECT_ORIENTED_NETWORK_CONFIGS]
+)
+@pytest.mark.usefixtures("_mock_endpoints")
+async def test_object_oriented_network_configs(unifi_controller, unifi_called_with):
+    """Test that we get the expected object-oriented network configuration."""
+    configs = unifi_controller.object_oriented_network_configs
+    await configs.update()
+    assert unifi_called_with(
+        "get", "/v2/api/site/default/object-oriented-network-configs"
+    )
+    assert len(configs.values()) == 2
+
+    config = configs["69f6b0a5e0e3ee2d4614cb5c"]
+    assert config.id == "69f6b0a5e0e3ee2d4614cb5c"
+    assert config.name == "Nintendo Switch - Block Internet"
+    assert config.enabled is True
+    assert config.target_type == "CLIENTS"
+    assert config.targets == ["98:b6:e9:b4:4c:29"]
+    assert config.secure["internet"]["mode"] == "TURN_OFF_INTERNET"
+    assert config.qos["enabled"] is False
+    assert config.route["enabled"] is False

--- a/tests/test_object_oriented_network_configs.py
+++ b/tests/test_object_oriented_network_configs.py
@@ -1,6 +1,6 @@
 """Test object-oriented network configuration API.
 
-pytest --cov-report term-missing --cov=aiounifi.object_oriented_network_config tests/test_object_oriented_network_configs.py
+pytest --cov-report term-missing --cov=aiounifi.models.object_oriented_network_config tests/test_object_oriented_network_configs.py
 """
 
 from copy import deepcopy

--- a/tests/test_object_oriented_network_configs.py
+++ b/tests/test_object_oriented_network_configs.py
@@ -200,3 +200,37 @@ async def test_object_oriented_network_config_optional_sections(unifi_controller
     assert config.secure["enabled"] is False
     assert config.qos["enabled"] is False
     assert config.route["enabled"] is False
+
+
+@pytest.mark.parametrize(
+    "object_oriented_network_config_payload",
+    [
+        [
+            {
+                "id": "69f6b0a5e0e3ee2d4614cb5c",
+                "enabled": True,
+                "name": "Nintendo Switch - Block Internet",
+                "target_type": "CLIENTS",
+                "targets": [{"type": "MAC", "value": "98:b6:e9:b4:4c:29"}],
+                "secure": {
+                    "enabled": True,
+                    "internet": {
+                        "mode": "TURN_OFF_INTERNET",
+                        "schedule": {"mode": "ALWAYS"},
+                    },
+                },
+                "qos": {"enabled": False},
+                "route": {"enabled": False},
+            }
+        ]
+    ],
+)
+@pytest.mark.usefixtures("_mock_endpoints")
+async def test_object_oriented_network_config_id_alias(unifi_controller):
+    """Test configs that use id instead of _id."""
+    configs = unifi_controller.object_oriented_network_configs
+    await configs.update()
+
+    config = configs["69f6b0a5e0e3ee2d4614cb5c"]
+    assert config.id == "69f6b0a5e0e3ee2d4614cb5c"
+    assert config.raw["_id"] == "69f6b0a5e0e3ee2d4614cb5c"


### PR DESCRIPTION
## Summary

Add support for UniFi Object-Oriented Network configuration objects, which are used by newer Policy Engine rules in the UniFi Network application.

This adds:
- a handler for `object_oriented_network_configs`
- list support for `/object-oriented-network-configs`
- update/toggle support for `/object-oriented-network-config/{id}`
- model properties for the rule name, enabled state, target type, targets, and secure/qos/route config blocks

## Context

Home Assistant can already expose legacy traffic rules/routes and zone-based firewall policies, but the UniFi UI now creates some simple Policy Engine rules as OON configs with generated firewall-policy rows underneath them. Those generated rows are marked predefined and are not the right object to update directly.

## Tests

- `python -m ruff check aiounifi tests pyproject.toml`
- `python -m pytest`
