### PR TITLE
fix: handle missing name field in FirewallPolicy

### DIFF
--- a/aiounifi/models/firewall_policy.py
+++ b/aiounifi/models/firewall_policy.py
@@ -29,7 +29,7 @@ class TypedFirewallPolicy(TypedDict):
 
     _id: str
     action: str
-    name: str
+    name: NotRequired[str]
     enabled: bool
     connection_state_type: str
     connection_states: list[str]
@@ -62,7 +62,7 @@ class FirewallPolicy(ApiItem):
     @property
     def name(self) -> str:
         """Firewall policy name."""
-        return self.raw["name"]
+        return self.raw.get("name", "")
 
     @property
     def enabled(self) -> bool:


### PR DESCRIPTION
## Problem
Some predefined/system UniFi firewall policies omit the name field from the API response, causing a KeyError: name crash when Home Assistant loads the UniFi integration.

## Fix
- Mark name as NotRequired in TypedFirewallPolicy
- Use .get('name') returning str | None, matching the existing pattern for description

## Reproduction
Any UniFi network with predefined zone-based firewall policies triggers this in the HA config_entries log.