### PR TITLE
Expose typed OON secure config

### DIFF
--- a/aiounifi/models/object_oriented_network_config.py
+++ b/aiounifi/models/object_oriented_network_config.py
@@ -104,7 +104,7 @@ class TypedObjectOrientedNetworkConfig(TypedDict):
     targets: NotRequired[list[str | ObjectOrientedNetworkTarget]]
     qos: NotRequired[ObjectOrientedNetworkQos]
     route: NotRequired[ObjectOrientedNetworkRoute]
-    secure: NotRequired[ObjectOrientedNetworkSecureT | None]
+    secure: NotRequired[ObjectOrientedNetworkSecureT]
 
 
 @dataclass

--- a/aiounifi/models/object_oriented_network_config.py
+++ b/aiounifi/models/object_oriented_network_config.py
@@ -22,7 +22,7 @@ class ObjectOrientedNetworkInternetMode(StrEnum):
 class ObjectOrientedNetworkSecureInternetT(TypedDict):
     """Internet access configuration."""
 
-    mode: ObjectOrientedNetworkInternetMode
+    mode: NotRequired[str]
     schedule: NotRequired[dict[str, str]]
 
 
@@ -67,7 +67,7 @@ class ObjectOrientedNetworkSecure:
     @classmethod
     def from_dict(cls, data: ObjectOrientedNetworkSecureT | None) -> Self:
         """Create security configuration."""
-        if not data:
+        if data is None:
             return cls()
 
         internet = data.get("internet")
@@ -75,7 +75,7 @@ class ObjectOrientedNetworkSecure:
             available=True,
             enabled=data.get("enabled") is True,
             internet=ObjectOrientedNetworkSecureInternet.from_dict(internet)
-            if internet
+            if internet is not None
             else None,
         )
 

--- a/aiounifi/models/object_oriented_network_config.py
+++ b/aiounifi/models/object_oriented_network_config.py
@@ -1,16 +1,45 @@
 """Object-oriented network configurations as part of a UniFi network."""
 
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import NotRequired, Self, TypedDict
 
 from .api import ApiItem, ApiRequestV2
 
 
-class ObjectOrientedNetworkInternet(TypedDict):
+class ObjectOrientedNetworkInternetMode(StrEnum):
+    """Possible internet access modes for security configuration."""
+
+    TURN_OFF_INTERNET = "TURN_OFF_INTERNET"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Set default enum member if an unknown internet mode is provided."""
+        return cls.UNKNOWN
+
+
+class ObjectOrientedNetworkSecureInternetT(TypedDict):
     """Internet access configuration."""
 
-    mode: str
+    mode: ObjectOrientedNetworkInternetMode
     schedule: NotRequired[dict[str, str]]
+
+
+@dataclass
+class ObjectOrientedNetworkSecureInternet:
+    """Represent internet access configuration."""
+
+    mode: ObjectOrientedNetworkInternetMode
+    schedule: dict[str, str] | None = None
+
+    @classmethod
+    def from_dict(cls, data: ObjectOrientedNetworkSecureInternetT) -> Self:
+        """Create internet access configuration."""
+        return cls(
+            mode=ObjectOrientedNetworkInternetMode(data.get("mode", "unknown")),
+            schedule=data.get("schedule"),
+        )
 
 
 class ObjectOrientedNetworkTarget(TypedDict):
@@ -20,11 +49,35 @@ class ObjectOrientedNetworkTarget(TypedDict):
     value: str
 
 
-class ObjectOrientedNetworkSecure(TypedDict):
+class ObjectOrientedNetworkSecureT(TypedDict):
     """Security configuration."""
 
     enabled: NotRequired[bool]
-    internet: NotRequired[ObjectOrientedNetworkInternet]
+    internet: NotRequired[ObjectOrientedNetworkSecureInternetT]
+
+
+@dataclass
+class ObjectOrientedNetworkSecure:
+    """Represent security configuration."""
+
+    available: bool = False
+    enabled: bool = False
+    internet: ObjectOrientedNetworkSecureInternet | None = None
+
+    @classmethod
+    def from_dict(cls, data: ObjectOrientedNetworkSecureT | None) -> Self:
+        """Create security configuration."""
+        if not data:
+            return cls()
+
+        internet = data.get("internet")
+        return cls(
+            available=True,
+            enabled=data.get("enabled") is True,
+            internet=ObjectOrientedNetworkSecureInternet.from_dict(internet)
+            if internet
+            else None,
+        )
 
 
 class ObjectOrientedNetworkQos(TypedDict):
@@ -51,7 +104,7 @@ class TypedObjectOrientedNetworkConfig(TypedDict):
     targets: NotRequired[list[str | ObjectOrientedNetworkTarget]]
     qos: NotRequired[ObjectOrientedNetworkQos]
     route: NotRequired[ObjectOrientedNetworkRoute]
-    secure: NotRequired[ObjectOrientedNetworkSecure]
+    secure: NotRequired[ObjectOrientedNetworkSecureT | None]
 
 
 @dataclass
@@ -115,8 +168,7 @@ class ObjectOrientedNetworkConfig(ApiItem):
     @property
     def secure(self) -> ObjectOrientedNetworkSecure:
         """Security configuration."""
-        default: ObjectOrientedNetworkSecure = {"enabled": False}
-        return default | self.raw.get("secure", {})
+        return ObjectOrientedNetworkSecure.from_dict(self.raw.get("secure"))
 
     @property
     def qos(self) -> ObjectOrientedNetworkQos:

--- a/tests/test_object_oriented_network_configs.py
+++ b/tests/test_object_oriented_network_configs.py
@@ -9,6 +9,7 @@ import pytest
 
 from aiounifi.models.object_oriented_network_config import (
     ObjectOrientedNetworkConfigUpdateRequest,
+    ObjectOrientedNetworkInternetMode,
 )
 
 OBJECT_ORIENTED_NETWORK_CONFIGS = [
@@ -171,7 +172,13 @@ async def test_object_oriented_network_configs(unifi_controller, unifi_called_wi
     assert config.enabled is True
     assert config.target_type == "CLIENTS"
     assert config.targets == ["98:b6:e9:b4:4c:29"]
-    assert config.secure["internet"]["mode"] == "TURN_OFF_INTERNET"
+    assert config.secure.available is True
+    assert config.secure.enabled is True
+    assert config.secure.internet is not None
+    assert (
+        config.secure.internet.mode
+        == ObjectOrientedNetworkInternetMode.TURN_OFF_INTERNET
+    )
     assert config.qos["enabled"] is False
     assert config.route["enabled"] is False
 
@@ -207,11 +214,71 @@ async def test_object_oriented_network_config_optional_section_defaults(
     config = configs["69f6b0a5e0e3ee2d4614cb5c"]
     assert config.target_type is None
     assert config.targets == []
-    assert config.secure["enabled"] is False
-    assert config.secure["internet"]["mode"] == "TURN_OFF_INTERNET"
+    assert config.secure.available is True
+    assert config.secure.enabled is False
+    assert config.secure.internet is not None
+    assert (
+        config.secure.internet.mode
+        == ObjectOrientedNetworkInternetMode.TURN_OFF_INTERNET
+    )
     assert config.qos["enabled"] is False
     assert config.route["enabled"] is False
     assert config.route["kill_switch"] is True
+
+
+@pytest.mark.parametrize(
+    "object_oriented_network_config_payload",
+    [
+        [
+            {
+                "_id": "69f6b0eae0e3ee2d4614cb91",
+                "enabled": True,
+                "name": "VPN traffic route",
+                "target_type": "NETWORKS",
+                "targets": ["6060b00f45de3905133cea14"],
+                "route": {"enabled": True},
+                "secure": None,
+            }
+        ]
+    ],
+)
+@pytest.mark.usefixtures("_mock_endpoints")
+async def test_object_oriented_network_config_secure_null(unifi_controller):
+    """Test security configuration with null secure data."""
+    configs = unifi_controller.object_oriented_network_configs
+    await configs.update()
+
+    config = configs["69f6b0eae0e3ee2d4614cb91"]
+    assert config.secure.available is False
+    assert config.secure.enabled is False
+    assert config.secure.internet is None
+
+
+@pytest.mark.parametrize(
+    "object_oriented_network_config_payload",
+    [
+        [
+            {
+                "_id": "69f6b0a5e0e3ee2d4614cb5c",
+                "enabled": True,
+                "name": "Nintendo Switch - Unknown Internet Mode",
+                "secure": {
+                    "enabled": True,
+                    "internet": {"mode": "SOMETHING_ELSE"},
+                },
+            }
+        ]
+    ],
+)
+@pytest.mark.usefixtures("_mock_endpoints")
+async def test_object_oriented_network_config_unknown_internet_mode(unifi_controller):
+    """Test unsupported internet mode maps to unknown."""
+    configs = unifi_controller.object_oriented_network_configs
+    await configs.update()
+
+    config = configs["69f6b0a5e0e3ee2d4614cb5c"]
+    assert config.secure.internet is not None
+    assert config.secure.internet.mode == ObjectOrientedNetworkInternetMode.UNKNOWN
 
 
 @pytest.mark.parametrize(

--- a/tests/test_object_oriented_network_configs.py
+++ b/tests/test_object_oriented_network_configs.py
@@ -291,14 +291,13 @@ async def test_object_oriented_network_config_secure_internet_empty(
                 "target_type": "NETWORKS",
                 "targets": ["6060b00f45de3905133cea14"],
                 "route": {"enabled": True},
-                "secure": None,
             }
         ]
     ],
 )
 @pytest.mark.usefixtures("_mock_endpoints")
-async def test_object_oriented_network_config_secure_null(unifi_controller):
-    """Test security configuration with null secure data."""
+async def test_object_oriented_network_config_secure_missing(unifi_controller):
+    """Test security configuration with missing secure data."""
     configs = unifi_controller.object_oriented_network_configs
     await configs.update()
 

--- a/tests/test_object_oriented_network_configs.py
+++ b/tests/test_object_oriented_network_configs.py
@@ -231,6 +231,60 @@ async def test_object_oriented_network_config_optional_section_defaults(
     [
         [
             {
+                "_id": "69f6b0a5e0e3ee2d4614cb5c",
+                "enabled": True,
+                "name": "Nintendo Switch - Empty Secure",
+                "secure": {},
+            }
+        ]
+    ],
+)
+@pytest.mark.usefixtures("_mock_endpoints")
+async def test_object_oriented_network_config_secure_empty(unifi_controller):
+    """Test empty security configuration is available."""
+    configs = unifi_controller.object_oriented_network_configs
+    await configs.update()
+
+    config = configs["69f6b0a5e0e3ee2d4614cb5c"]
+    assert config.secure.available is True
+    assert config.secure.enabled is False
+    assert config.secure.internet is None
+
+
+@pytest.mark.parametrize(
+    "object_oriented_network_config_payload",
+    [
+        [
+            {
+                "_id": "69f6b0a5e0e3ee2d4614cb5c",
+                "enabled": True,
+                "name": "Nintendo Switch - Empty Secure Internet",
+                "secure": {"internet": {}},
+            }
+        ]
+    ],
+)
+@pytest.mark.usefixtures("_mock_endpoints")
+async def test_object_oriented_network_config_secure_internet_empty(
+    unifi_controller,
+):
+    """Test empty internet configuration uses safe defaults."""
+    configs = unifi_controller.object_oriented_network_configs
+    await configs.update()
+
+    config = configs["69f6b0a5e0e3ee2d4614cb5c"]
+    assert config.secure.available is True
+    assert config.secure.enabled is False
+    assert config.secure.internet is not None
+    assert config.secure.internet.mode == ObjectOrientedNetworkInternetMode.UNKNOWN
+    assert config.secure.internet.schedule is None
+
+
+@pytest.mark.parametrize(
+    "object_oriented_network_config_payload",
+    [
+        [
+            {
                 "_id": "69f6b0eae0e3ee2d4614cb91",
                 "enabled": True,
                 "name": "VPN traffic route",


### PR DESCRIPTION
This is the smaller model change requested from home-assistant/core#169675.

Home Assistant needs to decide whether an object-oriented network config is a secure internet-blocking config without reaching into raw payload data. This exposes that through typed model properties:

- `config.secure.available` is false when `secure` is missing or null, such as route-only configs
- `config.secure.enabled` exposes the secure rule enabled flag with a safe default
- `config.secure.internet` is `None` when no internet config is present
- `config.secure.internet.mode` exposes `TURN_OFF_INTERNET` as `ObjectOrientedNetworkInternetMode.TURN_OFF_INTERNET`

Unknown internet modes map to `ObjectOrientedNetworkInternetMode.UNKNOWN` so new UniFi modes do not break parsing.

Tests:
- `.venv/bin/python -m pytest -o addopts=''`
- `.venv/bin/python -m pytest -o addopts='' --cov-report term-missing --cov=aiounifi.models.object_oriented_network_config tests/test_object_oriented_network_configs.py`
- `.venv/bin/python -m ruff check aiounifi/models/object_oriented_network_config.py tests/test_object_oriented_network_configs.py`
- `.venv/bin/python -m ruff format --check aiounifi/models/object_oriented_network_config.py tests/test_object_oriented_network_configs.py`
- `.venv/bin/python -m mypy aiounifi/models/object_oriented_network_config.py`